### PR TITLE
small fixes for building on mac

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -22,6 +22,7 @@ if [ `uname` == Darwin ]; then
 fi
 
 cmake ../src \
+    -Wno-unused-function \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
     -DCMAKE_INSTALL_RPATH:STRING="${PREFIX}/lib" \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,7 +141,6 @@ if(NOT(CUDA_VERSION LESS 10.0))  # if CUDA version is > or = 10.0
     -gencode=arch=compute_75,code=compute_75") # make available to future hardware see JIT compilation : https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#just-in-time-compilation
   elseif(NOT(CUDA_VERSION LESS 8.0))  # if CUDA version is > or = 8.0
 	  set(CUDA_NVCC_FLAGS "-O2;\
-		-gencode=arch=compute_20,code=sm_20;\
 		-gencode=arch=compute_30,code=sm_30;\
 		-gencode=arch=compute_35,code=sm_35;\
 		-gencode=arch=compute_37,code=sm_37;\
@@ -325,9 +324,9 @@ target_link_libraries(
   ${TIFF_LIBRARIES}
   )
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
   target_link_libraries(cudaDecon rt)
-endif (UNIX)
+endif ()
 
 target_link_libraries(
   radialft


### PR DESCRIPTION
couple small changes that allow me to build on OSX with cuda 9.0/9.2/10.1.  I'm not going to worry about CI integration for now due to annoyances around building cuda stuff on mac, I'll just build them locally and upload manually to anaconda.

if tests pass, I'll merge since there's almost nothing being done here