### PR TITLE
can use non-rotationally averaged OTF and decon-then-deskew

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@
 ######################################################################
 
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.10)
 # cmake_policy(SET CMP0054 OLD) #Set IF statements to dereference variables like in CMAKE version < 3.1
 # cmake_policy(SET CMP0012 NEW) #Set IF statements to use values of numbers and booleans rather than pretend that they could be variables
 
@@ -26,7 +26,7 @@ set(PROJECT_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 # set -fPIC for all targets (for shared libraries)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-add_compile_definitions(cimg_display=0)
+#add_compile_definitions(cimg_display=0)
 
 ######################################################################
 #
@@ -72,7 +72,7 @@ foreach(config DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
 
     foreach(var CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${config} CMAKE_LIBRARY_OUTPUT_DIRECTORY_${config} CMAKE_RUNTIME_OUTPUT_DIRECTORY_${config})
         set(${var} "${CMAKE_BINARY_DIR}/${platform_dir}-${config}")
-        string(TOLOWER "${${var}}" ${var})
+        string(TOLOWER "${${var}}" ${var})  ## why TOLOWER?? --lin
     endforeach()
 
 endforeach()

--- a/src/OTF_TIFF_viewer.cpp
+++ b/src/OTF_TIFF_viewer.cpp
@@ -20,6 +20,5 @@ int main(int argc, char *argv[])
   for (unsigned i=0; i< btiff.size(); i++)
     btiff(i) = sqrt(abs(std::complex<float> (atiff(2*i), atiff(2*i+1))));
 
-  // btiff = btiff.max() - btiff;
-  btiff.display();
+  btiff.display(0, false);
 }

--- a/src/RL-Biggs-Andrews.cpp
+++ b/src/RL-Biggs-Andrews.cpp
@@ -44,21 +44,47 @@ static double intensity_overall0 = 0.;
 static bool bFirstTime = true;
 
 
+void  determine_OTF_dimensions(CImg<> &complexOTF, float dr_psf, float dz_psf,
+                              unsigned &nx_otf, unsigned &ny_otf, unsigned &nz_otf,
+                              float &dkx_otf, float &dky_otf, float &dkz_otf)
+{
+  if (complexOTF.depth() > 1) {  // indicating non-RA OTF
+    nx_otf = complexOTF.width() / 2;
+    ny_otf = complexOTF.height();
+    nz_otf = complexOTF.depth();
+  }
+  else {
+    nx_otf = complexOTF.height();
+    ny_otf = 1;   // indicator for a rotationally averaged OTF?
+    nz_otf = complexOTF.width() / 2;
+  }
+
+  dkx_otf = 1/((nx_otf-1)*2 * dr_psf);
+
+  if (ny_otf > 1)
+    dky_otf = 1/(ny_otf * dr_psf);
+  else
+    dky_otf = dkx_otf;
+
+  dkz_otf = 1/(nz_otf * dz_psf);
+}
+
 
 //***************************************************************************************************************
 //********************************************* RichardsonLucy_GPU  *********************************************
 //***************************************************************************************************************
 
 
-void RichardsonLucy_GPU(CImg<> & raw, float background, 
+void RichardsonLucy_GPU(CImg<> & raw, float background,
                         GPUBuffer & d_interpOTF, int nIter,
                         double deskewFactor, int deskewedNx, int extraShift,
                         int napodize, int nZblend,
-                        CPUBuffer &rotationMatrix, cufftHandle rfftplanGPU, 
+                        CPUBuffer &rotationMatrix, cufftHandle rfftplanGPU,
                         cufftHandle rfftplanInvGPU, CImg<> & raw_deskewed,
                         cudaDeviceProp *devProp,
                         bool bFlatStartGuess, float my_median,
                         bool bDoRescale,
+                        bool bSkewedDecon,
                         float padVal,
                         bool bDupRevStack,
                         bool UseOnlyHostMem,
@@ -107,18 +133,18 @@ void RichardsonLucy_GPU(CImg<> & raw, float background,
   if (nIter > 0 || raw_deskewed.size()>0 || rotationMatrix.getSize()) {
     apodize_GPU(&X_k, nx, ny, nz, napodize);
 
-	//**************************** Background subtraction ***********************************
+    //**************************** Background subtraction ***********************************
     // background subtraction (including thresholding by 0):
     // printf("background=%f\n", background);
     backgroundSubtraction_GPU(X_k, nx, ny, nz, background, devProp->maxGridSize[2]);
 
 
-	
-	//**************************** Bleach correction ***********************************
+
+    //**************************** Bleach correction ***********************************
 
     // Calculate sum for bleach correction:
     double intensity_overall = meanAboveBackground_GPU(X_k, nx, ny, nz, devProp->maxGridSize[2], myGPUdevice);
-    
+
     if (bDoRescale) {
         if (bFirstTime) {
           intensity_overall0 = intensity_overall;
@@ -131,59 +157,60 @@ void RichardsonLucy_GPU(CImg<> & raw, float background,
 #ifndef NDEBUG
     printf("intensity_overall=%lf\n", intensity_overall);
 #endif
-  
 
 
-	//**************************** Deskew ***********************************
-    if (fabs(deskewFactor) > 0.0) { //then deskew raw data along x-axis first:
 
-		GPUBuffer deskewedRaw(nz * ny * deskewedNx * sizeof(float), myGPUdevice, UseOnlyHostMem);
-		std::cout << "deskewedRaw allocated.  ";
-		cudaMemGetInfo(&free, &total);
-		std::cout << std::setw(8) << X_k.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" ;
-		
-		std::cout << " Deskewing. ";
+    //**************************** Deskew ***********************************
+    if (( !bSkewedDecon || raw_deskewed.size()>0 && nIter == 0)
+        && fabs(deskewFactor) > 0.0) { //then deskew raw data along x-axis first:
+
+        GPUBuffer deskewedRaw(nz * ny * deskewedNx * sizeof(float), myGPUdevice, UseOnlyHostMem);
+        std::cout << "deskewedRaw allocated.  ";
+        cudaMemGetInfo(&free, &total);
+        std::cout << std::setw(8) << deskewedRaw.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" ;
+
+        std::cout << " Deskewing... ";
     deskew_GPU(X_k, nx, ny, nz, deskewFactor, deskewedRaw, deskewedNx, extraShift, padVal);
 
       // update raw (i.e., X_k) and its dimension variables.
-		std::cout << "Copy deskewedRaw back to X_k. ";
-		X_k = deskewedRaw;
-		
-			  
-		nx = deskewedNx;
-		nxy = nx * ny;
-		nxy2 = (nx / 2 + 1)*ny; // x=N3, y=N2, z=N1 see: http://docs.nvidia.com/cuda/cufft/#multi-dimensional
+        std::cout << "Copy deskewedRaw back to X_k. ";
+        X_k = deskewedRaw;
 
-		cutilSafeCall(cudaHostUnregister(raw.data()));
-		raw.clear();
-		raw.assign(nx, ny, nz, 1);
 
-		if (nIter > 0)
-	        cutilSafeCall(cudaHostRegister(raw.data(), nz*nxy*sizeof(float), cudaHostRegisterPortable));
+        nx = deskewedNx;
+        nxy = nx * ny;
+        nxy2 = (nx / 2 + 1)*ny; // x=N3, y=N2, z=N1 see: http://docs.nvidia.com/cuda/cufft/#multi-dimensional
 
-		if (raw_deskewed.size()>0) {
-			// save deskewed raw data into "raw_deskewed"; if no decon iteration is requested, then return immediately.
-			std::cout << "Copy X_k into raw_deskewed. " ;
+        cutilSafeCall(cudaHostUnregister(raw.data()));
+        raw.clear();
+        raw.assign(nx, ny, nz, 1);
 
-			cudaError_t myCudaErr = cudaErrorHostMemoryAlreadyRegistered;
-			myCudaErr = cudaHostRegister(raw_deskewed.data(), nz*nxy * sizeof(float), cudaHostRegisterPortable);      //pin the destination CImg host RAM
-			if (myCudaErr != cudaErrorHostMemoryAlreadyRegistered)
-				  cutilSafeCall(myCudaErr); // ignore error if this memory has already been registered.
+        if (nIter > 0)
+            cutilSafeCall(cudaHostRegister(raw.data(), nz*nxy*sizeof(float), cudaHostRegisterPortable));
 
-			cutilSafeCall(cudaMemcpy(raw_deskewed.data(), X_k.getPtr(),
-				nz*nxy*sizeof(float), cudaMemcpyDefault));
+        if (raw_deskewed.size()>0) {
+            // save deskewed raw data into "raw_deskewed"; if no decon iteration is requested, then return immediately.
+            std::cout << "Copy X_k into raw_deskewed. " ;
+
+            cudaError_t myCudaErr = cudaErrorHostMemoryAlreadyRegistered;
+            myCudaErr = cudaHostRegister(raw_deskewed.data(), nz*nxy * sizeof(float), cudaHostRegisterPortable);      //pin the destination CImg host RAM
+            if (myCudaErr != cudaErrorHostMemoryAlreadyRegistered)
+                  cutilSafeCall(myCudaErr); // ignore error if this memory has already been registered.
+
+            cutilSafeCall(cudaMemcpy(raw_deskewed.data(), X_k.getPtr(),
+                nz*nxy*sizeof(float), cudaMemcpyDefault));
         if (nIter == 0)
           return;
       }
-		std::cout << "Done." << std::endl;
+        std::cout << "Done." << std::endl;
     } // deskewedRaw should be destructed and that memory freed.
 
 
-	//**************************** Z blend ***********************************
+    //**************************** Z blend ***********************************
 
     if (nZblend > 0)
       zBlend_GPU(X_k, nx, ny, nz, nZblend);
-    
+
     /***** Duplicate reversed stack to minimize ringing in Z ******/
     if (bDupRevStack) {
       GPUBuffer X_k2(nz*2 * nxy * sizeof(float), myGPUdevice, false);
@@ -206,160 +233,160 @@ void RichardsonLucy_GPU(CImg<> & raw, float background,
 
   { // these guys are needed only during RL iterations, we can deallocate them once we are done with iterations.  output we need is only rawGPUbuf and X_k.
 
-	  GPUBuffer CC(nz * nxy * sizeof(float), myGPUdevice, UseOnlyHostMem); // RL factor to apply to Y_k to get X_k
-	  std::cout << "CC allocated.           ";
-	  cudaMemGetInfo(&free, &total);
-	  std::cout << std::setw(8) << CC.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
+      GPUBuffer CC(nz * nxy * sizeof(float), myGPUdevice, UseOnlyHostMem); // RL factor to apply to Y_k to get X_k
+      std::cout << "CC allocated.           ";
+      cudaMemGetInfo(&free, &total);
+      std::cout << std::setw(8) << CC.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
 
-	  std::cout << "rawGPUbuf allocated.    ";
-	  cudaMemGetInfo(&free, &total);
-	  std::cout << std::setw(8) << rawGPUbuf.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
-
-
-	  GPUBuffer X_kminus1(nz * nxy * sizeof(float), myGPUdevice, UseOnlyHostMem); // guess at the end of previous RL iteration
-	  std::cout << "X_kminus1 allocated.    ";
-	  cudaMemGetInfo(&free, &total);
-	  std::cout << std::setw(8) << X_kminus1.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
+      std::cout << "rawGPUbuf allocated.    ";
+      cudaMemGetInfo(&free, &total);
+      std::cout << std::setw(8) << rawGPUbuf.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
 
 
-	  GPUBuffer Y_k(nz * nxy * sizeof(float), myGPUdevice, false); // guess at beginning of RL iteration
-	  std::cout << "Y_k allocated.          ";
-	  cudaMemGetInfo(&free, &total);
-	  std::cout << std::setw(8) << Y_k.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
+      GPUBuffer X_kminus1(nz * nxy * sizeof(float), myGPUdevice, UseOnlyHostMem); // guess at the end of previous RL iteration
+      std::cout << "X_kminus1 allocated.    ";
+      cudaMemGetInfo(&free, &total);
+      std::cout << std::setw(8) << X_kminus1.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
 
 
-	  GPUBuffer G_kminus1(nz * nxy * sizeof(float), myGPUdevice, UseOnlyHostMem); // X_k - Y_k (RL change)
-	  std::cout << "G_kminus1 allocated.    ";
-	  cudaMemGetInfo(&free, &total);
-	  std::cout << std::setw(8) << G_kminus1.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
-
-	  GPUBuffer G_kminus2(nz * nxy * sizeof(float), myGPUdevice, UseOnlyHostMem); // previous X_k - Y_k (change between prediction and acceleration)
-	  std::cout << "G_kminus2 allocated.    ";
-	  cudaMemGetInfo(&free, &total);
-	  std::cout << std::setw(8) << G_kminus2.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
+      GPUBuffer Y_k(nz * nxy * sizeof(float), myGPUdevice, false); // guess at beginning of RL iteration
+      std::cout << "Y_k allocated.          ";
+      cudaMemGetInfo(&free, &total);
+      std::cout << std::setw(8) << Y_k.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
 
 
-	  /*  testing using 2D texture for OTF interpolation
-		CImg<> realpart(otf.width()/2, otf.height()), imagpart(realpart);
-	  #pragma omp parallel for
-		cimg_forXY(realpart, x, y) {
-		  realpart(x, y) = otf(2*x  , y);
-		  imagpart(x, y) = otf(2*x+1, y);
-		}
+      GPUBuffer G_kminus1(nz * nxy * sizeof(float), myGPUdevice, UseOnlyHostMem); // X_k - Y_k (RL change)
+      std::cout << "G_kminus1 allocated.    ";
+      cudaMemGetInfo(&free, &total);
+      std::cout << std::setw(8) << G_kminus1.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
 
-		prepareOTFtexture(realpart.data(), imagpart.data(), realpart.width(), realpart.height());
-
-		CPUBuffer interpOTF(d_interpOTF); //.getSize());
-		// d_interpOTF.set(&interpOTF, 0, interpOTF.getSize(), 0);
-
-		CImg<float> otfarr((float *) interpOTF.getPtr(), nz*2, nx/2+1);
-		otfarr.save("interpOTF.tif");
-
-		return;
-		debugging code ends
-	  */
-	  // Allocate GPU buffer for temp FFT result
-	  GPUBuffer fftGPUbuf(nz * nxy2 * sizeof(cuFloatComplex), myGPUdevice, UseOnlyHostMem); // This is the complex FFT output.
-	  std::cout << "fftGPUbuf allocated.    ";
-	  cudaMemGetInfo(&free, &total);
-	  std::cout << std::setw(8) << fftGPUbuf.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
+      GPUBuffer G_kminus2(nz * nxy * sizeof(float), myGPUdevice, UseOnlyHostMem); // previous X_k - Y_k (change between prediction and acceleration)
+      std::cout << "G_kminus2 allocated.    ";
+      cudaMemGetInfo(&free, &total);
+      std::cout << std::setw(8) << G_kminus2.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
 
 
-	  double lambda = 0; // acceleration factor
-	  float eps = std::numeric_limits<float>::epsilon();
+      /*  testing using 2D texture for OTF interpolation
+        CImg<> realpart(otf.width()/2, otf.height()), imagpart(realpart);
+      #pragma omp parallel for
+        cimg_forXY(realpart, x, y) {
+          realpart(x, y) = otf(2*x  , y);
+          imagpart(x, y) = otf(2*x+1, y);
+        }
+
+        prepareOTFtexture(realpart.data(), imagpart.data(), realpart.width(), realpart.height());
+
+        CPUBuffer interpOTF(d_interpOTF); //.getSize());
+        // d_interpOTF.set(&interpOTF, 0, interpOTF.getSize(), 0);
+
+        CImg<float> otfarr((float *) interpOTF.getPtr(), nz*2, nx/2+1);
+        otfarr.save("interpOTF.tif");
+
+        return;
+        debugging code ends
+      */
+      // Allocate GPU buffer for temp FFT result
+      GPUBuffer fftGPUbuf(nz * nxy2 * sizeof(cuFloatComplex), myGPUdevice, UseOnlyHostMem); // This is the complex FFT output.
+      std::cout << "fftGPUbuf allocated.    ";
+      cudaMemGetInfo(&free, &total);
+      std::cout << std::setw(8) << fftGPUbuf.getSize() / (1024 * 1024) << "MB" << std::setw(8) << free / (1024 * 1024) << "MB free" << std::endl;
 
 
-	  //****************************************************************************
-	  //****************************RL Iterations ***********************************
-	  //****************************************************************************
-
-	  // R-L iteration
-	  for (int k = 0; k < nIter; k++) {
+      double lambda = 0; // acceleration factor
+      float eps = std::numeric_limits<float>::epsilon();
 
 
-		  std::cout << "Iteration ";
-		  int OldstdoutWidth = std::cout.width(2);
-		  std::cout << k;
-		  std::cout.width(OldstdoutWidth);
-		  std::cout << ". ";
+      //****************************************************************************
+      //****************************RL Iterations ***********************************
+      //****************************************************************************
 
-		  char GPUmessage[50];
-		  sprintf(GPUmessage, "Iter %d", k);
-		  PUSH_RANGE(GPUmessage, k)
-
-			  // a. Make an image predictions for the next iteration    
-			  if (k > 1) {
-				  lambda = calcAccelFactor(G_kminus1, G_kminus2, nx, ny, nz, eps, myGPUdevice); // (G_km1 dot G_km2) / (G_km2 dot G_km2)
-				  lambda = std::max(std::min(lambda, 1.), 0.); // stability enforcement
-
-				  printf("Lambda = %.2f. ", lambda);
-
-				  updatePrediction(Y_k, X_k, X_kminus1, lambda, nx, ny, nz, devProp->maxGridSize[2]); // Y_k = X_k + lambda * (X_k - X_kminus1)
-			  }
-
-			  else if (bFlatStartGuess && k == 0)
-			  {
-				  std::cout << "Median. ";
-				  CImg<float> FlatStartGuess(raw, "xyzc", my_median); //create a buffer and fill with median value of image.
-				  std::cout << "Copy Median to Y_k. ";
-				  cutilSafeCall(cudaHostRegister(FlatStartGuess.data(), nz*nxy * sizeof(float), cudaHostRegisterPortable)); //pin the host RAM
-				  // transfer host data to GPU
-				  cutilSafeCall(cudaMemcpy(Y_k.getPtr(), FlatStartGuess.data(), nz*nxy * sizeof(float),
-					  cudaMemcpyDefault));
-				  cutilSafeCall(cudaHostUnregister(FlatStartGuess.data()));
-				  ~FlatStartGuess;
-			  }
-			  else
-			  {
-				  std::cout << "Cpy X_k to Y_k.";
-				  Y_k = X_k; // copy data (not pointer) from X_k to Y_k (= operator has been redefined)
-			  }
+      // R-L iteration
+      for (int k = 0; k < nIter; k++) {
 
 
-		  std::cout << "Copy X_k to X_k-1. ";
-		  cutilSafeCall(cudaMemcpyAsync(X_kminus1.getPtr(), X_k.getPtr(),				//copy previous guess to X_kminus1
-			  X_k.getSize(), cudaMemcpyDefault));
+          std::cout << "Iteration ";
+          int OldstdoutWidth = std::cout.width(2);
+          std::cout << k;
+          std::cout.width(OldstdoutWidth);
+          std::cout << ". ";
 
-		  if (k > 0) {
-			  std::cout << "Copy G_k-1 to G_k-2. ";
-			  cutilSafeCall(cudaMemcpyAsync(G_kminus2.getPtr(), G_kminus1.getPtr(),
-				  G_kminus1.getSize(), cudaMemcpyDefault));
-		  }
+          char GPUmessage[50];
+          sprintf(GPUmessage, "Iter %d", k);
+          PUSH_RANGE(GPUmessage, k)
+
+              // a. Make an image predictions for the next iteration
+              if (k > 1) {
+                  lambda = calcAccelFactor(G_kminus1, G_kminus2, nx, ny, nz, eps, myGPUdevice); // (G_km1 dot G_km2) / (G_km2 dot G_km2)
+                  lambda = std::max(std::min(lambda, 1.), 0.); // stability enforcement
+
+                  printf("Lambda = %.2f. ", lambda);
+
+                  updatePrediction(Y_k, X_k, X_kminus1, lambda, nx, ny, nz, devProp->maxGridSize[2]); // Y_k = X_k + lambda * (X_k - X_kminus1)
+              }
+
+              else if (bFlatStartGuess && k == 0)
+              {
+                  std::cout << "Median. ";
+                  CImg<float> FlatStartGuess(raw, "xyzc", my_median); //create a buffer and fill with median value of image.
+                  std::cout << "Copy Median to Y_k. ";
+                  cutilSafeCall(cudaHostRegister(FlatStartGuess.data(), nz*nxy * sizeof(float), cudaHostRegisterPortable)); //pin the host RAM
+                  // transfer host data to GPU
+                  cutilSafeCall(cudaMemcpy(Y_k.getPtr(), FlatStartGuess.data(), nz*nxy * sizeof(float),
+                      cudaMemcpyDefault));
+                  cutilSafeCall(cudaHostUnregister(FlatStartGuess.data()));
+                  ~FlatStartGuess;
+              }
+              else
+              {
+                  std::cout << "Cpy X_k to Y_k.";
+                  Y_k = X_k; // copy data (not pointer) from X_k to Y_k (= operator has been redefined)
+              }
 
 
-		  std::cout << "Filter1. ";
-		  // b.  Make core for the LR estimation ( raw/reblurred_current_estimation )
-		  CC = Y_k;
-		  filterGPU(CC, nx, ny, nz, rfftplanGPU, rfftplanInvGPU, fftGPUbuf, d_interpOTF,
-			  false, devProp->maxGridSize[2]);
+          std::cout << "Copy X_k to X_k-1. ";
+          cutilSafeCall(cudaMemcpyAsync(X_kminus1.getPtr(), X_k.getPtr(),               //copy previous guess to X_kminus1
+              X_k.getSize(), cudaMemcpyDefault));
+
+          if (k > 0) {
+              std::cout << "Copy G_k-1 to G_k-2. ";
+              cutilSafeCall(cudaMemcpyAsync(G_kminus2.getPtr(), G_kminus1.getPtr(),
+                  G_kminus1.getSize(), cudaMemcpyDefault));
+          }
 
 
-		  // if (k==0) {
-		  //   CPUBuffer CC_cpu(CC);
-		  //   CImg<> CCimg((float *) CC_cpu.getPtr(), nx, ny, nz, 1, true);
-		  //   CCimg.save_tiff("afterFilter0.tif");
-		  // }
-
-		  std::cout << "LRcore. ";
-
-		  calcLRcore(CC, rawGPUbuf, nx, ny, nz, devProp->maxGridSize[2]);
+          std::cout << "Filter1. ";
+          // b.  Make core for the LR estimation ( raw/reblurred_current_estimation )
+          CC = Y_k;
+          filterGPU(CC, nx, ny, nz, rfftplanGPU, rfftplanInvGPU, fftGPUbuf, d_interpOTF,
+              false, devProp->maxGridSize[2]);
 
 
-		  // c. Determine next iteration image & apply positivity constraint
-		  // X_kminus1 = X_k;
+          // if (k==0) {
+          //   CPUBuffer CC_cpu(CC);
+          //   CImg<> CCimg((float *) CC_cpu.getPtr(), nx, ny, nz, 1, true);
+          //   CCimg.save_tiff("afterFilter0.tif");
+          // }
 
-		  std::cout << "Filter2. ";
-		  filterGPU(CC, nx, ny, nz, rfftplanGPU, rfftplanInvGPU, fftGPUbuf, d_interpOTF,
-			  true, devProp->maxGridSize[2]);
+          std::cout << "LRcore. ";
+
+          calcLRcore(CC, rawGPUbuf, nx, ny, nz, devProp->maxGridSize[2]);
 
 
-		  updateCurrEstimate(X_k, CC, Y_k, nx, ny, nz, devProp->maxGridSize[2]); //updated current estimate: Y_k * CC plus positivity constraint. "X_k" is updated upon return.
+          // c. Determine next iteration image & apply positivity constraint
+          // X_kminus1 = X_k;
 
-		  // G_kminus2 = G_kminus1;
-		  calcCurrPrevDiff(X_k, Y_k, G_kminus1, nx, ny, nz, devProp->maxGridSize[2]); //G_kminus1 = X_k - Y_k change from RL
-		  std::cout << "Done. " << std::endl;
-		  POP_RANGE
-	  }
+          std::cout << "Filter2. ";
+          filterGPU(CC, nx, ny, nz, rfftplanGPU, rfftplanInvGPU, fftGPUbuf, d_interpOTF,
+              true, devProp->maxGridSize[2]);
+
+
+          updateCurrEstimate(X_k, CC, Y_k, nx, ny, nz, devProp->maxGridSize[2]); //updated current estimate: Y_k * CC plus positivity constraint. "X_k" is updated upon return.
+
+          // G_kminus2 = G_kminus1;
+          calcCurrPrevDiff(X_k, Y_k, G_kminus1, nx, ny, nz, devProp->maxGridSize[2]); //G_kminus1 = X_k - Y_k change from RL
+          std::cout << "Done. " << std::endl;
+          POP_RANGE
+      }
   } // iterations complete. Deallocate GPUbuffers that we don't need.  Just keep X_k
   //************************************************************************************
   //****************************RL Iterations complete**********************************
@@ -370,11 +397,28 @@ void RichardsonLucy_GPU(CImg<> & raw, float background,
     // even though X_k contains double-sized stack.
     nz /= 2;
 
+  if (bSkewedDecon && fabs(deskewFactor) > 0.0) { //deskew after decon
+    GPUBuffer deskewedAfter(nz * ny * deskewedNx * sizeof(float), myGPUdevice, UseOnlyHostMem);
+    std::cout << "deskewedAfter allocated.  ";
+    cudaMemGetInfo(&free, &total);
+    std::cout << std::setw(8) << deskewedAfter.getSize() / (1<<20) << "MB" << std::setw(8) << free / (1<<20) << "MB free" ;
+
+    std::cout << " Deskewing after deconv... ";
+    deskew_GPU(X_k, nx, ny, nz, deskewFactor, deskewedAfter, deskewedNx, extraShift);
+    X_k = deskewedAfter;
+    nx = deskewedNx;
+    nxy = nx * ny;
+    cutilSafeCall(cudaHostUnregister(raw.data()));
+    raw.clear();
+    raw.assign(nx, ny, nz, 1);
+    cutilSafeCall(cudaHostRegister(raw.data(), nz*nxy*sizeof(float), cudaHostRegisterPortable));
+  }
+
   // Rotate decon result if requested:
-  
+
   if (rotationMatrix.getSize()) {
-	  std::cout << "Rotating...";
-    
+      std::cout << "Rotating...";
+
     float *p = (float *) rotationMatrix.getPtr();
     // Refer to rotMatrix definition in main():
     int nz_afterRot = nz * p[3] / p[0];
@@ -393,20 +437,20 @@ void RichardsonLucy_GPU(CImg<> & raw, float background,
     cutilSafeCall(cudaMemcpy(raw.data(), d_rotatedResult.getPtr(),
                              nz_afterRot * nx_afterRot * ny * sizeof(float),
                              cudaMemcpyDefault));
-	std::cout << "Done." << std::endl;
+    std::cout << "Done." << std::endl;
   }
 
   else {
     // Download from device memory back to "raw":
     cutilSafeCall(cudaMemcpy(raw.data(), X_k.getPtr(), nz*nxy*sizeof(float),
-		cudaMemcpyDefault));
+        cudaMemcpyDefault));
   }
 
   if (nIter > 0)
     cutilSafeCall(cudaHostUnregister(raw.data()));
 
   if (raw_deskewed.size())
-	cudaHostUnregister(raw_deskewed.data()); // ignore error
+    cudaHostUnregister(raw_deskewed.data()); // ignore error
 
 #ifndef NDEBUG
   printf("%f msecs\n", stopwatch.getTime());
@@ -459,7 +503,7 @@ unsigned get_output_nz()
     return output_nz;
   }
 
-  
+
 }
 
 int RL_interface_init(int nx, int ny, int nz, // raw image dimensions
@@ -468,6 +512,7 @@ int RL_interface_init(int nx, int ny, int nz, // raw image dimensions
                       float deskewAngle, // deskew
                       float rotationAngle,
                       int outputWidth,
+                      bool bSkewedDecon,
                       char * OTF_file_name) // device might not work, since d_interpOTF is a global and device is set at compile time.
 {
 
@@ -504,10 +549,22 @@ int RL_interface_init(int nx, int ny, int nz, // raw image dimensions
     std::cerr << e.what() << std::endl; //OTF_file_name << " cannot be opened\n";
     return 0;
   }
-  unsigned nr_otf = complexOTF.height();
-  unsigned nz_otf = complexOTF.width() / 2;
-  float dkr_otf = 1/((nr_otf-1)*2 * dr_psf);
-  float dkz_otf = 1/(nz_otf * dz_psf);
+  // unsigned nr_otf = complexOTF.height();
+  // unsigned nz_otf = complexOTF.width() / 2;
+  // float dkr_otf = 1/((nr_otf-1)*2 * dr_psf);
+  // float dkz_otf = 1/(nz_otf * dz_psf);
+  unsigned nx_otf, ny_otf, nz_otf;
+  float dkx_otf, dkz_otf, dky_otf;
+  if (bSkewedDecon)
+    dz_psf *= fabs(sin(deskewAngle * M_PI/180.));
+  determine_OTF_dimensions(complexOTF, dr_psf, dz_psf, nx_otf, ny_otf, nz_otf,
+                           dkx_otf, dky_otf, dkz_otf);
+
+  GPUBuffer d_rawOTF(0, false);
+  d_rawOTF.resize(nx_otf * ny_otf * nz_otf * sizeof(cuFloatComplex));
+  cutilSafeCall(cudaMemcpy(d_rawOTF.getPtr(), complexOTF.data(),
+                           d_rawOTF.getSize(), cudaMemcpyDefault));
+
 
   // Obtain deskew factor and new x dimension if deskew is run:
   deskewFactor = 0.;
@@ -523,7 +580,7 @@ int RL_interface_init(int nx, int ny, int nz, // raw image dimensions
 
     deskewedXdim = findOptimalDimension(deskewedXdim);
     // update z step size: (this is fine even though dz is a function parameter)
-    dz *= sin(deskewAngle * M_PI/180.);
+    dz *= fabs(sin(deskewAngle * M_PI/180.));
   }
 
   // Construct rotation matrix:
@@ -555,14 +612,18 @@ int RL_interface_init(int nx, int ny, int nz, // raw image dimensions
   float dky = 1.0/(dr * output_ny);
   float dkz = 1.0/(dz * output_nz);
   float eps = std::numeric_limits<float>::epsilon();
-  transferConstants(deskewedXdim, output_ny, output_nz, nr_otf, nz_otf,
-                    dkx/dkr_otf, dky/dkr_otf, dkz/dkz_otf,
-                    eps, complexOTF.data());
+  transferConstants(deskewedXdim, output_ny, output_nz, nx_otf, ny_otf, nz_otf,
+                    dkx/dkx_otf, dky/dky_otf, dkz/dkz_otf, eps);
 
   // make a 3D interpolated OTF array:
-  d_interpOTF.resize(output_nz * output_ny * (deskewedXdim+2) * sizeof(float));
-  // catch exception here
-  makeOTFarray(d_interpOTF, deskewedXdim, output_ny, output_nz);
+  if (bSkewedDecon) {
+    d_interpOTF.resize(output_nz * output_ny * (output_nx/2+1)* 2 * sizeof(float));
+    makeOTFarray(d_rawOTF, d_interpOTF, deskewedXdim, output_ny, output_nz);
+  }
+  else {
+    d_interpOTF.resize(output_nz * output_ny * (deskewedXdim+2) * sizeof(float));
+    makeOTFarray(d_rawOTF, d_interpOTF, deskewedXdim, output_ny, output_nz);
+  }
   return 1;
 }
 
@@ -577,7 +638,8 @@ int RL_interface(const unsigned short * const raw_data,
                  int extraShift,
                  int napodize, int nZblend,
                  float padVal,
-                 bool bDupRevStack
+                 bool bDupRevStack,
+                 bool bSkewedDecon
                  )
 {
 
@@ -588,7 +650,7 @@ int RL_interface(const unsigned short * const raw_data,
     raw_image.crop(0, 0, 0, 0, output_nx-1, output_ny-1, output_nz-1, 0);
 
   cudaDeviceProp deviceProp;
-  cudaGetDeviceProperties(&deviceProp, 0); 
+  cudaGetDeviceProperties(&deviceProp, 0);
 
   // Finally do calculation including deskewing, decon, rotation:
   CImg<> raw_deskewed;
@@ -601,7 +663,8 @@ int RL_interface(const unsigned short * const raw_data,
   RichardsonLucy_GPU(raw_image, background, d_interpOTF, nIters,
                      deskewFactor, deskewedXdim, extraShift, napodize, nZblend, rotMatrix,
                      rfftplanGPU, rfftplanInvGPU, raw_deskewed, &deviceProp,
-                     bFlatStartGuess, my_median, bDoRescale, padVal, bDupRevStack, false);
+                     bFlatStartGuess, my_median, bDoRescale, padVal, bDupRevStack,
+                     bSkewedDecon, false);
 
   // Copy deconvolved data, stored in raw_image, to "result" for return:
   memcpy(result, raw_image.data(), raw_image.size() * sizeof(float));

--- a/src/RL_interface_driver.cpp
+++ b/src/RL_interface_driver.cpp
@@ -12,7 +12,7 @@ int main(int argc, char *argv[])
   // Step 1: call RL_interface_init() once for all images to be 
   // acquired at this session; see linearDecon.h for detailed parameter descriptions
   RL_interface_init(raw.width(), raw.height(), raw.depth(),
-                    .104, .4, .104, .1, -32.8, -32.8, 0, argv[2], 0);
+                    .104, .4, .104, .1, -32.8, -32.8, 0, 0, argv[2]);
 
   // Step 2: allocate buffer for result image, whose dimension might be different than 
   // the raw because CUFFT prefers dimensions to be factorizable to 2, 3, 5, and 7
@@ -21,7 +21,7 @@ int main(int argc, char *argv[])
 
   // Step 3: call the gut of RL deconvolution; see linearDecon.h for detailed parameter descriptions
   // raw.data() and result.data() are just the plain pointers to the memory underneath "raw" and "results" CImg objects
-  RL_interface(raw.data(), raw.width(), raw.height(), raw.depth(), result.data(), 90., 10, 0, 0, 0);
+  RL_interface(raw.data(), raw.width(), raw.height(), raw.depth(), result.data(), 90., 10, 0, 0, 0, 0);
 
   // Saving result into a file for debug; not essential.
   result.save("debug.tif");

--- a/src/linearDecon.cpp
+++ b/src/linearDecon.cpp
@@ -19,52 +19,51 @@ CImg<> DeskewedToSave;
 
 int load_next_thread(const char* my_path)
 {
-    next_file_image.assign(my_path);
-    if (false)
-    {
-        float img_max = next_file_image(0, 0, 0);
-        float img_min = next_file_image(0, 0, 0);
-        cimg_forXYZ(next_file_image, x, y, z) {
-            img_max = std::max(next_file_image(x, y, z), img_max);
-            img_min = std::min(next_file_image(x, y, z), img_min);
-        }
-        std::cout << "next_file_image : " << next_file_image.width() << " x " << next_file_image.height() << " x " << next_file_image.depth() << ". " << std::endl;
-        std::cout << "         next_file_image max, min : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
-        std::cout << "Loaded from " << my_path << std::endl;
+  next_file_image.assign(my_path);
+  if (false) {
+    float img_max = next_file_image(0, 0, 0);
+    float img_min = next_file_image(0, 0, 0);
+    cimg_forXYZ(next_file_image, x, y, z) {
+      img_max = std::max(next_file_image(x, y, z), img_max);
+      img_min = std::min(next_file_image(x, y, z), img_min);
     }
+    std::cout << "next_file_image : " << next_file_image.width() << " x " << next_file_image.height() << " x " << next_file_image.depth() << ". " << std::endl;
+    std::cout << "         next_file_image max, min : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
+    std::cout << "Loaded from " << my_path << std::endl;
+  }
 
-    return 0;
+  return 0;
 }
 
 unsigned compression = 0;
 
 int save_in_thread(std::string inputFileName, const float *const voxel_size, float dz)
 {
-    std::string temp = "ImageJ=1.50i\n"
-                       "spacing=" + std::to_string(dz) + "\n"
-                       "unit=micron";
-    const char *description = temp.c_str();
-    ToSave.save_tiff(makeOutputFilePath(inputFileName).c_str(), compression, voxel_size, description);
+  std::string temp = "ImageJ=1.50i\n"
+    "spacing=" + std::to_string(dz) + "\n"
+    "unit=micron";
+  const char *description = temp.c_str();
+  ToSave.save_tiff(makeOutputFilePath(inputFileName).c_str(), compression, voxel_size, description);
 
-    return 0;
+  return 0;
 }
 
 int U16save_in_thread(std::string inputFileName, const float *const voxel_size, float dz)
 {
-    std::string temp = "ImageJ=1.50i\n"
-                       "spacing=" + std::to_string(dz) + "\n"
-                       "unit=micron";
-    const char *description = temp.c_str();
-    U16ToSave.save_tiff(makeOutputFilePath(inputFileName).c_str(), compression, voxel_size, description);
+  std::string temp = "ImageJ=1.50i\n"
+    "spacing=" + std::to_string(dz) + "\n"
+    "unit=micron";
+  const char *description = temp.c_str();
+  U16ToSave.save_tiff(makeOutputFilePath(inputFileName).c_str(), compression, voxel_size, description);
 
-    return 0;
+  return 0;
 }
 
 int DeSkewsave_in_thread(std::string inputFileName, const float *const voxel_size, const char *const description)
 {
-    DeskewedToSave.save_tiff(makeOutputFilePath(inputFileName, "Deskewed", "_deskewed").c_str(), compression, voxel_size, description);
-    //raw_deskewed.save_tiff(makeOutputFilePath(*it,           "Deskewed", "_deskewed").c_str(), compression, voxel_size, description);
-    return 0;
+  DeskewedToSave.save_tiff(makeOutputFilePath(inputFileName, "Deskewed", "_deskewed").c_str(), compression, voxel_size, description);
+  //raw_deskewed.save_tiff(makeOutputFilePath(*it,           "Deskewed", "_deskewed").c_str(), compression, voxel_size, description);
+  return 0;
 }
 
 
@@ -72,152 +71,153 @@ std::complex<float> otfinterpolate(std::complex<float> * otf, float kx, float ky
 // Use sub-pixel coordinates (kx,ky,kz) to linearly interpolate a rotationally-averaged 3D OTF ("otf").
 // otf has 2 dimensions: fast dimension is kz with length "nzotf" while the slow dimension is kr.
 {
-    int irindex, izindex, indices[2][2];
-    float krindex, kzindex;
-    float ar, az;
+  int irindex, izindex, indices[2][2];
+  float krindex, kzindex;
+  float ar, az;
 
-    krindex = sqrt(kx*kx + ky*ky);
-    kzindex = (kz<0 ? kz+nzotf : kz);
+  krindex = sqrt(kx*kx + ky*ky);
+  kzindex = (kz<0 ? kz+nzotf : kz);
 
-    if (krindex < nrotf-1 && kzindex < nzotf) {
-        irindex = floor(krindex);
-        izindex = floor(kzindex);
+  if (krindex < nrotf-1 && kzindex < nzotf) {
+    irindex = floor(krindex);
+    izindex = floor(kzindex);
 
-        ar = krindex - irindex;
-        az = kzindex - izindex;  // az is always 0 for 2D case, and it'll just become a 1D interp
+    ar = krindex - irindex;
+    az = kzindex - izindex;  // az is always 0 for 2D case, and it'll just become a 1D interp
 
-        if (izindex == nzotf-1) {
-            indices[0][0] = irindex*nzotf+izindex;
-            indices[0][1] = irindex*nzotf+0;
-            indices[1][0] = (irindex+1)*nzotf+izindex;
-            indices[1][1] = (irindex+1)*nzotf+0;
-        }
-        else {
-            indices[0][0] = irindex*nzotf+izindex;
-            indices[0][1] = irindex*nzotf+(izindex+1);
-            indices[1][0] = (irindex+1)*nzotf+izindex;
-            indices[1][1] = (irindex+1)*nzotf+(izindex+1);
-        }
-
-        return (1-ar)*(otf[indices[0][0]]*(1-az) + otf[indices[0][1]]*az) +
-               ar*(otf[indices[1][0]]*(1-az) + otf[indices[1][1]]*az);
+    if (izindex == nzotf-1) {
+      indices[0][0] = irindex*nzotf+izindex;
+      indices[0][1] = irindex*nzotf+0;
+      indices[1][0] = (irindex+1)*nzotf+izindex;
+      indices[1][1] = (irindex+1)*nzotf+0;
     }
-    else
-        return std::complex<float>(0, 0);
+    else {
+      indices[0][0] = irindex*nzotf+izindex;
+      indices[0][1] = irindex*nzotf+(izindex+1);
+      indices[1][0] = (irindex+1)*nzotf+izindex;
+      indices[1][1] = (irindex+1)*nzotf+(izindex+1);
+    }
+
+    return (1-ar)*(otf[indices[0][0]]*(1-az) + otf[indices[0][1]]*az) +
+      ar*(otf[indices[1][0]]*(1-az) + otf[indices[1][1]]*az);
+  }
+  else
+    return std::complex<float>(0, 0);
 }
 
 int wienerfilter(CImg<> & g, float dkx, float dky, float dkz,
                  CImg<> & otf, float dkr_otf, float dkz_otf,
                  float rcutoff, float wiener)
 {
-    /* 'g' is the raw data's FFT (half kx axis); it is also the result upon return */
-    int i, j, k;
-    float kz, ky, kx;
-    float amp2, rho, kxscale, kyscale, kzscale, kr;
-    std::complex<float> A_star_g, otf_val;
-    float w;
+  /* 'g' is the raw data's FFT (half kx axis); it is also the result upon return */
+  int i, j, k;
+  float kz, ky, kx;
+  float amp2, rho, kxscale, kyscale, kzscale, kr;
+  std::complex<float> A_star_g, otf_val;
+  float w;
 
-    w = wiener*wiener;
-    kxscale = dkx/dkr_otf;
-    kyscale = dky/dkr_otf;
-    kzscale = dkz/dkz_otf;
+  w = wiener*wiener;
+  kxscale = dkx/dkr_otf;
+  kyscale = dky/dkr_otf;
+  kzscale = dkz/dkz_otf;
 
-    int nx = g.width()/2; // '/2' because g is CImg<float> hijacked for complex storage
-    int ny = g.height();
-    int nz = g.depth();
+  int nx = g.width()/2; // '/2' because g is CImg<float> hijacked for complex storage
+  int ny = g.height();
+  int nz = g.depth();
 
-    std::complex<float> result;
+  std::complex<float> result;
 
-    #pragma omp parallel for private(k, i, j, kz, ky, kx, kr, otf_val, amp2, A_star_g, rho, result)
-    for (k=0; k<nz; k++) {
-        kz = ( k>nz/2 ? k-nz : k );
-        for (i=0; i<ny; i++) {
-            ky = ( i > ny/2 ? i-ny : i );
-            for (j=0; j<nx; j++) {
-                kx = j;
-                kr = sqrt(kx*kx*dkx*dkx + ky*ky*dky*dky);
-                if (kr <=rcutoff) {
-                    otf_val = otfinterpolate((std::complex<float>*) otf.data(),
-                                             kx*kxscale, ky*kyscale,
-                                             kz*kzscale, otf.width()/2, otf.height());
+#pragma omp parallel for private(k, i, j, kz, ky, kx, kr, otf_val, amp2, A_star_g, rho, result)
+  for (k=0; k<nz; k++) {
+    kz = ( k>nz/2 ? k-nz : k );
+    for (i=0; i<ny; i++) {
+      ky = ( i > ny/2 ? i-ny : i );
+      for (j=0; j<nx; j++) {
+        kx = j;
+        kr = sqrt(kx*kx*dkx*dkx + ky*ky*dky*dky);
+        if (kr <=rcutoff) {
+          otf_val = otfinterpolate((std::complex<float>*) otf.data(),
+                                   kx*kxscale, ky*kyscale,
+                                   kz*kzscale, otf.width()/2, otf.height());
 
-                    amp2 = otf_val.real() * otf_val.real() + otf_val.imag() * otf_val.imag();
-                    A_star_g = std::conj(otf_val) * std::complex<float>(g(2*j, i, k), g(2*j+1, i, k));
+          amp2 = otf_val.real() * otf_val.real() + otf_val.imag() * otf_val.imag();
+          A_star_g = std::conj(otf_val) * std::complex<float>(g(2*j, i, k), g(2*j+1, i, k));
 
-                    /* apodization */
-                    rho = kr / rcutoff;
-                    result = A_star_g / (amp2+w) * (1-rho);
-                    g(2*j, i, k) = result.real();
-                    g(2*j+1, i, k) = result.imag();
-                }
-                else {
-                    g(2*j, i, k) = 0;
-                    g(2*j+1, i, k) = 0;
-                }
-            }
+          /* apodization */
+          rho = kr / rcutoff;
+          result = A_star_g / (amp2+w) * (1-rho);
+          g(2*j, i, k) = result.real();
+          g(2*j+1, i, k) = result.imag();
         }
+        else {
+          g(2*j, i, k) = 0;
+          g(2*j+1, i, k) = 0;
+        }
+      }
     }
-    return 0;
+  }
+  return 0;
 }
 
 int main(int argc, char *argv[])
 {
-    #ifdef _WIN32
-    HANDLE  hConsole;
-    hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+#ifdef _WIN32
+  HANDLE  hConsole;
+  hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 
-    SetConsoleTextAttribute(hConsole, 11); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-    printf("Created at Howard Hughes Medical Institute Janelia Research Campus. Copyright 2020. All rights reserved.\n");
-    SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-    #endif
-    std::clock_t start_t;
-    double duration;
-    double iter_duration = 0;
+  SetConsoleTextAttribute(hConsole, 11); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+  printf("Created at Howard Hughes Medical Institute Janelia Research Campus. Copyright 2020. All rights reserved.\n");
+  SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+  std::clock_t start_t;
+  double duration;
+  double iter_duration = 0;
 
 
-    start_t = std::clock();
+  start_t = std::clock();
 
-    int napodize, nZblend;
-    float background;
-    float NA=1.2;
-    ImgParams imgParams, imgParamsOld;
-    float dz_psf, dr_psf;
-    float wiener;
+  int napodize, nZblend;
+  float background;
+  float NA=1.2;
+  ImgParams imgParams, imgParamsOld;
+  float dz_psf, dr_psf;
+  float wiener;
 
-    int myGPUdevice=0;
-    int RL_iters=0;
-    bool bSaveDeskewedRaw = false;
-    bool bDontAdjustResolution = false;
+  int myGPUdevice=0;
+  int RL_iters=0;
+  bool bSaveDeskewedRaw = false;
+  bool bDontAdjustResolution = false;
 
-    bool BlendTileOverlap = false;
-    float deskewAngle=0.0;
-    float rotationAngle=0.0;
-    unsigned outputWidth;
-    float padVal = 0.0;
+  bool BlendTileOverlap = false;
+  float deskewAngle=0.0;
+  bool bSkewedDecon = false;
+  float rotationAngle=0.0;
+  unsigned outputWidth;
+  float padVal = 0.0;
 
-    int extraShift=0;
-    std::vector<int> final_CropTo_boundaries;
-    bool bSaveUshort = false;
-    std::vector<bool> bDoMaxIntProj;
-    std::vector<bool> bDoRawMaxIntProj;
-    std::vector< CImg<> > MIprojections;
-    int Pad = 0;
-    bool bFlatStartGuess = false;
-    bool bDoRescale = false;
-    bool UseOnlyHostMem = false;
-    bool no_overwrite = false;
-    bool lzw = false;
-    int skip = 0;
-    bool bDupRevStack = false;
-    int tile_size=0;
-    int tile_requested = 0;
-    int tile_overlap_requested = 20;
+  int extraShift=0;
+  std::vector<int> final_CropTo_boundaries;
+  bool bSaveUshort = false;
+  std::vector<bool> bDoMaxIntProj;
+  std::vector<bool> bDoRawMaxIntProj;
+  std::vector< CImg<> > MIprojections;
+  int Pad = 0;
+  bool bFlatStartGuess = false;
+  bool bDoRescale = false;
+  bool UseOnlyHostMem = false;
+  bool no_overwrite = false;
+  bool lzw = false;
+  int skip = 0;
+  bool bDupRevStack = false;
+  int tile_size=0;
+  int tile_requested = 0;
+  int tile_overlap_requested = 20;
 
-    TIFFSetWarningHandler(NULL);
+  TIFFSetWarningHandler(NULL);
 
-    std::string datafolder, filenamePattern, otffiles, LSfile;
-    po::options_description progopts("cudaDeconv. Version: " + version_number + "\n");
-    progopts.add_options()
+  std::string datafolder, filenamePattern, otffiles, LSfile;
+  po::options_description progopts("cudaDeconv. Version: " + version_number + "\n");
+  progopts.add_options()
     ("drdata", po::value<float>(&imgParams.dr)->default_value(.104), "Image x-y pixel size (um)")
     ("dzdata,z", po::value<float>(&imgParams.dz)->default_value(.25), "Image z step (um)")
     ("drpsf", po::value<float>(&dr_psf)->default_value(.104), "PSF x-y pixel size (um)")
@@ -230,7 +230,9 @@ int main(int argc, char *argv[])
     ("dupRevStack,d", po::bool_switch(&bDupRevStack)->default_value(false), "Duplicate reversed stack prior to decon to reduce Z ringing")
     ("NA,n", po::value<float>(&NA)->default_value(1.2), "Numerical aperture")
     ("RL,i", po::value<int>(&RL_iters)->default_value(15), "Run Richardson-Lucy, and set how many iterations")
-    ("deskew,D", po::value<float>(&deskewAngle)->default_value(0.0), "Deskew angle; if not 0.0 then perform deskewing before deconv")
+    ("deskew,D", po::value<float>(&deskewAngle)->default_value(0.0), "Deskew angle; if not 0.0 then perform deskewing before or after deconv")
+    ("dcbds", po::bool_switch(&bSkewedDecon)->implicit_value(true),
+     "If deskewing, do it after decon; require sample-scan PSF and non-RA OTF")
     ("padval", po::value<float>(&padVal)->default_value(0.0), "Value to pad image with when deskewing")
     ("width,w", po::value<unsigned>(&outputWidth)->default_value(0), "If deskewed, the output image's width")
     ("shift,x", po::value<int>(&extraShift)->default_value(0), "If deskewed, the output image's extra shift in X (positive->left")
@@ -260,1111 +262,1138 @@ int main(int argc, char *argv[])
     // ("GPUdevice", po::value<int>(&myGPUdevice)->default_value(0), "Index of GPU device to use (0=first device)")
     // ("UseOnlyHostMem", po::bool_switch(&UseOnlyHostMem)->default_value(false), "Just use Host Mapped Memory, and not GPU. For debugging only.")
     ;
-    po::positional_options_description p;
-    p.add("input-dir", 1);
-    p.add("filename-pattern", 1);
-    p.add("otf-file", 1);
+  po::positional_options_description p;
+  p.add("input-dir", 1);
+  p.add("filename-pattern", 1);
+  p.add("otf-file", 1);
 
-    std::string commandline_string = __DATE__ ;
+  std::string commandline_string = __DATE__ ;
+  commandline_string.append(" ");
+  commandline_string.append(__TIME__);
+  for (int i = 0; i < argc; i++) {
     commandline_string.append(" ");
-    commandline_string.append(__TIME__);
-    for (int i = 0; i < argc; i++) {
-        commandline_string.append(" ");
-        commandline_string.append(argv[i]);
-    } // store commandline_string
+    commandline_string.append(argv[i]);
+  } // store commandline_string
 
 
     // Parse commandline option:
-    po::variables_map varsmap;
-    try {
-        if (argc == 1)  { //if no arguments, show help.
-            std::cout << progopts << "\n";
-            return 0;
-        }
-
-        store(po::command_line_parser(argc, argv).
-              options(progopts).positional(p).run(), varsmap);
-        if (varsmap.count("help")) {
-            std::cout << progopts << "\n";
-            return 0;
-        }
-
-        if (varsmap.count("version")) {
-            std::cout << version_number << "\n";
-            return 0;
-        }
-
-
-        //****************************Query GPU devices***********************************
-        if (varsmap.count("DevQuery")) {
-            int deviceCount = 0;
-            cudaGetDeviceCount(&deviceCount);
-            // This function call returns 0 if there are no CUDA capable devices.
-            if (deviceCount != 0)
-                printf("Detected %d CUDA Capable device(s)\n", deviceCount);
-
-            int dev, driverVersion = 0, runtimeVersion = 0;
-
-            for (dev = 0; dev < deviceCount; ++dev)
-            {
-                cudaSetDevice(dev);
-                cudaDeviceProp mydeviceProp;
-                cudaGetDeviceProperties(&mydeviceProp, dev);
-                printf("\nDevice %d: \"%s\"\n", dev, mydeviceProp.name);
-
-                cudaDriverGetVersion(&driverVersion);
-                cudaRuntimeGetVersion(&runtimeVersion);
-                printf("  CUDA Driver Version / Runtime Version          %d.%d / %d.%d\n", driverVersion / 1000, (driverVersion % 100) / 10, runtimeVersion / 1000, (runtimeVersion % 100) / 10);
-                printf("  CUDA Capability Major/Minor version number:    %d.%d\n", mydeviceProp.major, mydeviceProp.minor);
-                printf("  Total amount of global memory:                 %.0f MBytes (%llu bytes)\n",
-                       (float)mydeviceProp.totalGlobalMem / 1048576.0f, (unsigned long long) mydeviceProp.totalGlobalMem);
-            }
-            return 0; // added return because I want query to simply query and quit
-        }
-
-        notify(varsmap);
-
-        // if (varsmap.count("crop")) {
-        //   if (final_CropTo_boundaries.size() != 6)
-        //     throw std::runtime_error("Exactly 6 integers are required for the -C or --crop flag!");
-        //   std::copy(final_CropTo_boundaries.begin(), final_CropTo_boundaries.end(), std::ostream_iterator<int>(std::cout, ", "));
-        //   std::cout << std::endl;
-        // }
-        // std::cout << bDoMaxIntProj.size() << std::endl;
-    }
-    catch (std::exception &e) {
-        std::cout << "\n!!Error occurred: " << e.what() << std::endl;
-        return 0;
+  po::variables_map varsmap;
+  try {
+    if (argc == 1)  { //if no arguments, show help.
+      std::cout << progopts << "\n";
+      return 0;
     }
 
-    bool bAdjustResolution = !bDontAdjustResolution;
-    imgParamsOld = imgParams; // Copy image Params
-
-    //****************************Check to see if we have a proper GPU device***********************************
-    int deviceCount = 0;
-    cudaError_t error_id = cudaGetDeviceCount(&deviceCount);
-    if (error_id != cudaSuccess)
-    {
-        printf("cudaGetDeviceCount returned %d\n-> %s\n", (int)error_id, cudaGetErrorString(error_id));
-        printf("Result = FAIL\n");
-        exit(EXIT_FAILURE);
+    store(po::command_line_parser(argc, argv).
+          options(progopts).positional(p).run(), varsmap);
+    if (varsmap.count("help")) {
+      std::cout << progopts << "\n";
+      return 0;
     }
-    if (deviceCount == 0)
-        printf("There are no available device(s) that support CUDA\n");
 
-
-    cudaSetDeviceFlags(cudaDeviceMapHost);
-    size_t GPUfree;
-    size_t GPUtotal;
-    cudaMemGetInfo(&GPUfree, &GPUtotal);
-    cudaDeviceProp mydeviceProp;
-    cudaGetDeviceProperties(&mydeviceProp, myGPUdevice);
-
-    #ifdef _WIN32
-    SetConsoleTextAttribute(hConsole, 13); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-    #endif
-
-    std::cout << std::endl << "Built : " << __DATE__ << " " << __TIME__ << ".  GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total on " << mydeviceProp.name << std::endl;
-
-    CImg<> raw_image, raw_imageFFT, complexOTF, raw_deskewed, LSImage, sub_image, file_image, stitch_image, blend_weight_image;
-    CImg<float> AverageLS;
-    float dkr_otf, dkz_otf;
-    float dkx, dky, dkz, rdistcutoff;
-    fftwf_plan rfftplan=NULL, rfftplan_inv=NULL;
-    CPUBuffer rotMatrix;
-    double deskewFactor=0;
-    bool bCrop = false;
-    unsigned new_ny, new_nz, new_nx;
-    int deskewedXdim = 0;
-    cufftHandle rfftplanGPU = NULL, rfftplanInvGPU = NULL;
-    GPUBuffer d_interpOTF(1, myGPUdevice, UseOnlyHostMem);
-    GPUBuffer workArea(1, myGPUdevice, UseOnlyHostMem);
-
-    cudaDeviceProp deviceProp;
-    cudaGetDeviceProperties(&deviceProp, myGPUdevice);
-
-    unsigned nx, ny, nz = 0;
-
-    int border_x = 0;
-    int border_y = 0;
-    int border_z = 0;
-
-	float voxel_size [3];
-	float voxel_size_decon [3];
-	float imdz;
-	const char *description;
-
-    if (lzw) {
-        compression = 1;
+    if (varsmap.count("version")) {
+      std::cout << version_number << "\n";
+      return 0;
     }
-    //****************************Main processing***********************************
-    // Loop over all matching input TIFFs, :
-    try {
 
 
-        std::cout << "Looking for files to process... " ;
-        // Gather all files in 'datafolder' and matching the file name pattern:
-        //bool MIPsOnly = (RL_iters == 0 && bDoMaxIntProj.size() == 3);
+    //****************************Query GPU devices***********************************
+    if (varsmap.count("DevQuery")) {
+      int deviceCount = 0;
+      cudaGetDeviceCount(&deviceCount);
+      // This function call returns 0 if there are no CUDA capable devices.
+      if (deviceCount != 0)
+        printf("Detected %d CUDA Capable device(s)\n", deviceCount);
 
-        std::vector< std::string > all_matching_files = gatherMatchingFiles(datafolder, filenamePattern, no_overwrite);
-        std::cout << "Found " << all_matching_files.size() << " file(s)." << std::endl ;
+      int dev, driverVersion = 0, runtimeVersion = 0;
 
-        #ifdef _WIN32
-        SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-        #endif
-        if (all_matching_files.size() == 0) {
-            #ifdef _WIN32
-            SetConsoleTextAttribute(hConsole, 10); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-            #endif
-            std::cout<< "\nNo files need processing!" << std::endl;
-            #ifdef _WIN32
-            SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-            #endif
-            return 0;
+      for (dev = 0; dev < deviceCount; ++dev)
+        {
+          cudaSetDevice(dev);
+          cudaDeviceProp mydeviceProp;
+          cudaGetDeviceProperties(&mydeviceProp, dev);
+          printf("\nDevice %d: \"%s\"\n", dev, mydeviceProp.name);
+
+          cudaDriverGetVersion(&driverVersion);
+          cudaRuntimeGetVersion(&runtimeVersion);
+          printf("  CUDA Driver Version / Runtime Version          %d.%d / %d.%d\n", driverVersion / 1000, (driverVersion % 100) / 10, runtimeVersion / 1000, (runtimeVersion % 100) / 10);
+          printf("  CUDA Capability Major/Minor version number:    %d.%d\n", mydeviceProp.major, mydeviceProp.minor);
+          printf("  Total amount of global memory:                 %.0f MBytes (%llu bytes)\n",
+                 (float)mydeviceProp.totalGlobalMem / 1048576.0f, (unsigned long long) mydeviceProp.totalGlobalMem);
         }
-
-
-        std::vector<std::string>::iterator next_it = all_matching_files.begin() + skip;//make a second incrementer that will be used to load the next raw image while we process.
-
-        std::thread t1; // thread for loading files
-        t1 = std::thread(load_next_thread, next_it->c_str());   //start loading the first file.
-
-        std::thread tsave;  // thread for saving decon
-        std::thread tDeskewsave; // thread for saving deskewed
-
-        for (std::vector<std::string>::iterator it= all_matching_files.begin() + skip;
-                it != all_matching_files.end(); it++) {
-
-            int number_of_files_left = all_matching_files.end() - it;
-
-            #ifdef _WIN32
-            SetConsoleTextAttribute(hConsole, 10); // colors are 9=blue 10=green and so on to 15=white
-            #endif
-            std::cout << std::endl << "Loading raw_image: " << it - all_matching_files.begin() + 1 << " out of " << all_matching_files.size() << ".   ";
-            if (it > all_matching_files.begin() + skip) // if this isn't the first iteration.
-            {
-                int seconds = number_of_files_left * iter_duration;
-                int hours = ceil(seconds / (60 * 60));
-                int minutes = ceil((seconds - (hours * 60 * 60)) / 60);
-                std::cout << (int)iter_duration << " s/file.   " << number_of_files_left << " files left.  " << hours << " hours, " <<  minutes << " minutes remaining.";
-            }
-
-            std::cout <<  std::endl;
-            #ifdef _WIN32
-            SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-            #endif
-
-            std::cout << std::endl << *it << std::endl;
-            std::cout << "Waiting for separate thread to finish loading image... " ;
-            t1.join();        // wait for loading thread to finish reading next_raw_image into memory.
-            t1.~thread();     // destroy thread.
-            std::cout << "Image loaded. Copying to 'file_image'... " ;
-            file_image.assign(next_file_image, false); // Copy to file_image.  CImg<T>& assign(const CImg<t>& img, const bool is_shared)
-
-            float img_max = file_image(0, 0);
-            float img_min = file_image(0, 0);
-
-            #ifndef NDEBUG
-            cimg_forXYZ(file_image, x, y, z) {
-                img_max = std::max(file_image(x, y, z), img_max);
-                img_min = std::min(file_image(x, y, z), img_min);
-            }
-
-            std::cout << "         raw img max, min : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
-            #endif
-
-
-
-            std::cout << "Done." << std::endl;
-
-            // start reading the next image
-            next_it++; // increment next_it.  This will now have the next file to read.
-            if (it < all_matching_files.end() - 1)  // If there are more files to process...
-                t1 = std::thread(load_next_thread, next_it->c_str());		//start new thread and load the next file, while we process file_image
-
-            //**************************** Tiling setup ***********************************
-            int number_of_tiles = 1;
-            int number_of_overlaps = 0;
-            double tile_overlap = 0;
-
-
-            if (tile_requested < 0) {
-                tile_size = std::min(           128, file_image.height());
-            }
-            if (tile_requested > 0) {
-                tile_size = std::min(tile_requested, file_image.height());
-            }
-
-            number_of_tiles = ceil((double)file_image.height() / ((double)tile_size - tile_overlap_requested)); // try for 20 pixel overlap
-            number_of_overlaps = number_of_tiles - 1;
-            tile_overlap = (((double)tile_size * number_of_tiles) - file_image.height()) / number_of_overlaps;
-            tile_overlap = floor(tile_overlap); //
-
-
-            if (tile_requested == 0) {
-                number_of_tiles = 1;
-                tile_size = file_image.height();
-                tile_overlap = 0;
-                number_of_overlaps = 0;
-            }
-            std::cout << std::endl << "# of tiles: " << number_of_tiles << ". # of overlaps: " << number_of_overlaps << ". Tile size: " << tile_size << " Y pix. Overlap: " << tile_overlap << " Y pix. " << std::endl;
-
-            for (int tile_index = 0; tile_index < number_of_tiles; tile_index++) {
-                int tile_y_offset = floor( (double)tile_index*(tile_size - tile_overlap) );
-                //std::cout << std::endl << "tile_y_offset: " << tile_y_offset;
-
-                if (number_of_tiles > 1) {
-
-                    //int y_end = std::min(file_image.height(), tile_size + tile_y_offset);
-                    int y_end = tile_size + tile_y_offset; // I think we can crop to outside the image, and the boundry conditions will fill it. This way each subimage is exactly the same size, which makes the rest of the code mighty happy.
-
-
-                    raw_image = file_image.get_crop(0,	/* X start */
-                                                    tile_y_offset,					/* Y start */
-                                                    0,								/* Z start */
-                                                    file_image.width() - 1,			/*  X end */
-                                                    y_end - 1,						/*  Y end */
-                                                    file_image.depth() - 1,			/*  Z end */
-                                                    true); // get sub_image. raw_image = sub_image
-
-
-                    //for (int y = tile_y_offset; y < y_end; ++y) {
-
-                    //cimg_forXZ(file_image, x, z) {
-                    //raw_image(x, y_raw_index, z) = (unsigned long) file_image(x, y, z);
-                    //}
-                    //y_raw_index = y_raw_index + 1;
-                    //}
-                    //raw_image = file_image.get_crop(0,
-                    //	tile_y_offset,
-                    //	0,
-                    //	0,
-                    //	file_image.width() - 1,
-                    //	std::min(file_image.height(), tile_size + tile_y_offset) - 1,
-                    //	file_image.depth() - 1,
-                    //	0); // get sub_image. raw_image = sub_image
-					#ifdef _WIN32
-                    SetConsoleTextAttribute(hConsole, 10); // colors are 9=blue 10=green and so on to 15=white
-					#endif
-                    std::cout << std::endl << "Tile: " << tile_index + 1 << " out of " << number_of_tiles << ".   " << std::endl;
-					#ifdef _WIN32
-                    SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-                    #endif
-					// raw_image.save(makeOutputFilePath(it->c_str(), "tile", "_tile").c_str()); //for debugging
-                }
-                else
-                    raw_image.assign(file_image);
-
-                // If it's the first input file, initialize a bunch including:
-                // 1. crop image to make dimensions nice factorizable numbers
-                // 2. calculate deskew parameters, new X dimensions
-                // 3. calculate rotation matrix
-                // 4. create FFT plans
-                // 5. transfer constants into GPU device constant memory
-                // 6. make 3D OTF array in device memory
-
-                bool bDifferent_sized_raw_img = (nx != raw_image.width() || ny != raw_image.height() || nz != raw_image.depth() ); // Check if raw.image has changed size from first iteration
-
-                if (it != all_matching_files.begin() + skip && bDifferent_sized_raw_img) {
-                    #ifdef _WIN32
-                    SetConsoleTextAttribute(hConsole, 14); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-                    #endif
-                    std::cout << std::endl << "File " << it - all_matching_files.begin() + 1 << " has a different size" << std::endl;
-                }
-                std::cout << "raw_image size             : " << raw_image.width() << " x " << raw_image.height() << " x " << raw_image.depth() << std::endl;
-                #ifdef _WIN32
-                SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-                #endif
-
-
-                //**************************** If first image OR if raw_img has changed size ***********************************
-                if (nx == 0 || bDifferent_sized_raw_img ) {
-                    nx = raw_image.width();
-                    ny = raw_image.height();
-                    nz = raw_image.depth();
-                    imgParams = imgParamsOld;
-
-
-
-                    //****************************Adjust resolution if desired***********************************
-
-                    int step_size;
-
-                    if (fabs(deskewAngle) > 0.0 || fabs(rotationAngle) > 0.0)
-                    {
-                        Pad = 0;	// Currently padding is disabled if we are deskewing or rotating.
-                        std::cout << "Currently padding is disabled if we are deskewing or rotating." << std::endl;
-                    }
-
-                    if (Pad)
-                        step_size =  1;
-                    else
-                        step_size = -1;
-
-                    int startnx = nx;
-                    int startny = ny;
-                    int startnz = nz;
-
-                    if (Pad) //pad by N number of border pixels
-                    {
-                        startnx = startnx + Pad * 2;
-                        startny = startny + Pad * 2;
-                        startnz = startnz + Pad * 2;
-                        std::cout << "Min padding to use is " << Pad << " pixels." << std::endl;
-                    }
-
-                    if (RL_iters > 0 && (bAdjustResolution || Pad)) {
-                        new_ny = findOptimalDimension(startny, step_size);
-                        if (new_ny != startny) {
-                            printf("new ny=%d\n", new_ny);
-                            bCrop = true;
-                        }
-
-                        new_nz = findOptimalDimension(startnz, step_size);
-                        if (new_nz != startnz) {
-                            printf("new nz=%d\n", new_nz);
-                            bCrop = true;
-                        }
-
-                        // only if no deskewing is happening do we want to change image width here
-                        new_nx = startnx;
-                        if (!(fabs(deskewAngle) > 0.0)) {
-                            new_nx = findOptimalDimension(startnx, step_size);
-                            if (new_nx != startnx) {
-                                printf("new nx=%d\n", new_nx);
-                                bCrop = true;
-                            }
-                        }
-                    }
-                    else {
-                        new_nx = nx;
-                        new_ny = ny;
-                        new_nz = nz;
-                    }
-
-
-                    //****************************Load OTF to CPU RAM(assuming 3D rotationally averaged OTF)***********************************
-                    std::cout <<  "Loading OTF... ";
-                    complexOTF.assign(otffiles.c_str());
-                    unsigned nr_otf = complexOTF.height();		// because it is rotationally averaged, kx = ky = kr
-                    unsigned nz_otf = complexOTF.width() / 2;	// because we are storing complex data in the .tiff file as two pixels: the real "width" is half the number of pixels in a row.
-                    dkr_otf = 1/((nr_otf-1)*2 * dr_psf);
-                    dkz_otf = 1/(nz_otf * dz_psf);
-                    std::cout << "nr x nz     : " << nr_otf << " x " << nz_otf << ". " << std::endl << std::endl ;
-
-
-                    //****************************Construct deskew matrix***********************************
-                    deskewedXdim = new_nx;
-                    if (fabs(deskewAngle) > 0.0) {
-                        float old_dz = imgParams.dz;
-                        if (deskewAngle <0) deskewAngle += 180.;
-                        deskewFactor = cos(deskewAngle * M_PI/180.) * imgParams.dz / imgParams.dr;
-                        if (outputWidth ==0)
-                            deskewedXdim += floor(new_nz * imgParams.dz *
-                                                  fabs(cos(deskewAngle * M_PI/180.)) / imgParams.dr);
-                        // TODO: sometimes deskewedXdim calc'ed this way is too large
-                        else
-                            deskewedXdim = outputWidth; // use user-provided output width if available
-
-                        // Adjust resolution to optimal FFT size if desired
-                        if (bAdjustResolution)
-                            deskewedXdim = findOptimalDimension(deskewedXdim);
-
-                        // update z step size:
-                        imgParams.dz *= sin(deskewAngle * M_PI/180.);
-                        if (fabs(deskewFactor) < 1)
-                        {
-                            #ifdef _WIN32
-                            SetConsoleTextAttribute(hConsole, 14); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-                            #endif
-                            printf("Warning : deskewFactor is < 1.  Check that angle, dz, and dr sizes are correct.\n");
-                            #ifdef _WIN32
-                            SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-                            #endif
-                        }
-                        printf("old dz = %f, dxy = %f, deskewFactor = %f, new nx = %d, new dz = %f\n", old_dz, imgParams.dr, deskewFactor, deskewedXdim, imgParams.dz);
-
-                    }
-
-
-
-                    //****************************Construct rotation matrix***********************************
-                    if (fabs(rotationAngle) > 0.0) {
-                        rotMatrix.resize(4*sizeof(float));
-                        rotationAngle *= M_PI/180;
-                        float stretch = imgParams.dr / imgParams.dz;
-                        float *p = (float *)rotMatrix.getPtr();
-                        p[0] = cos(rotationAngle) * stretch;
-                        p[1] = sin(rotationAngle) * stretch;
-                        p[2] = -sin(rotationAngle);
-                        p[3] = cos(rotationAngle);
-                    }
-
-
-
-                    if (wiener >0) {
-                        //****************************Wiener filter instead of RL (not usually used.):***********************************
-                        raw_imageFFT.assign(deskewedXdim+2, new_ny, new_nz);
-
-                        if (!fftwf_init_threads()) { /* one-time initialization required to use threads */
-                            printf("Error returned by fftwf_init_threads()\n");
-                        }
-
-                        fftwf_plan_with_nthreads(8);
-                        rfftplan = fftwf_plan_dft_r2c_3d(new_nz, new_ny, deskewedXdim,
-                                                         raw_image.data(),
-                                                         (fftwf_complex *) raw_imageFFT.data(),
-                                                         FFTW_ESTIMATE);
-                        rfftplan_inv = fftwf_plan_dft_c2r_3d(new_nz, new_ny, deskewedXdim,
-                                                             (fftwf_complex *) raw_imageFFT.data(),
-                                                             raw_image.data(),
-                                                             FFTW_ESTIMATE);
-                    }
-                    else if (RL_iters>0) {
-
-                        //****************************RL decon***********************************
-
-                        //****************************Create reusable cuFFT plans***********************************
-                        //
-                        size_t workSize = 0;
-                        cufftResult cuFFTErr;
-
-                        if (cufftGetSize(rfftplanGPU, &workSize) == CUFFT_SUCCESS) { // if plan existed before, destroy it before creating a new plan.
-                            cufftDestroy(rfftplanGPU);
-                            std::cout << "Destroying rfftplanGPU." << std::endl;
-                        }
-                        if (cufftGetSize(rfftplanInvGPU, &workSize) == CUFFT_SUCCESS) { // if plan existed before, destroy it before creating a new plan.
-                            cufftDestroy(rfftplanInvGPU);
-                            std::cout << "Destroying rfftplanInvGPU." << std::endl;
-                        }
-
-                        size_t GPUfree_prev;
-                        cudaMemGetInfo(&GPUfree_prev, &GPUtotal);
-
-                        unsigned nz_final;
-                        if (bDupRevStack)  // to reduce severe Z ringing
-                            nz_final = new_nz*2;
-                        else
-                            nz_final = new_nz;
-
-                        if (0) {
-                            // old way,  just autoallocate FFTplans.
-                            // This will always be on the GPU, and the two plans 
-                            // (even though are serially exectuted) cannot share workspace.
-                            cuFFTErr = cufftPlan3d(&rfftplanGPU, nz_final, new_ny, deskewedXdim, CUFFT_R2C);
-                            if (cuFFTErr != CUFFT_SUCCESS) {
-                                // std::cerr << "cufftPlan3d() r2c failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
-                                cudaMemGetInfo(&GPUfree, &GPUtotal);
-                                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
-
-                                cufftEstimate3d(nz_final, new_ny, deskewedXdim, CUFFT_R2C, &workSize);
-                                std::cerr << "R2C FFT Plan desires " << workSize / (1024 * 1024) << " MB. " << std::endl;
-                                throw std::runtime_error("cufftPlan3d() r2c failed.");
-                            }
-
-
-                            cuFFTErr = cufftPlan3d(&rfftplanInvGPU, nz_final, new_ny, deskewedXdim, CUFFT_C2R);
-                            if (cuFFTErr != CUFFT_SUCCESS) {
-                                // std::cerr << "cufftPlan3d() c2r failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
-                                cudaMemGetInfo(&GPUfree, &GPUtotal);
-                                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
-
-                                cufftEstimate3d(nz_final, new_ny, deskewedXdim, CUFFT_R2C, &workSize);
-                                std::cerr << "C2R FFT Plan desires " << workSize / (1024 * 1024) << " MB. " << std::endl;
-                                throw std::runtime_error("cufftPlan3d() c2r failed.");
-                            }
-                        }
-                        else { 
-                            // new way, share FFTplan workarea.
-                            // Possibly put this area on the Host RAM if it doesn't fit in GPU RAM.
-                            int autoAllocate   = 0;	// don't allocate, we want to specify the workspace ourselves.
-                            size_t workSizeR2C = 0; // size of R2C plan to be filled in by cuFFT
-                            size_t workSizeC2R = 0; // size of C2R plan to be filled in by cuFFT
-                            workSize    = 0; // necessary size of plan to enable R2C or C2R (i.e. max of these)
-
-                            cuFFTErr = cufftCreate(&rfftplanGPU);							// create object.
-                            cuFFTErr = cufftSetAutoAllocation(rfftplanGPU, autoAllocate);
-                            cuFFTErr = cufftMakePlan3d(rfftplanGPU, new_nz, new_ny, deskewedXdim, CUFFT_R2C, &workSizeR2C);   // make plan, retrieve needed workSize
-                            if (cuFFTErr != CUFFT_SUCCESS) {
-                                std::cerr << "cufftMakePlan3d() r2c failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
-                                cudaMemGetInfo(&GPUfree, &GPUtotal);
-                                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
-
-                                cuFFTErr = cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_R2C, &workSizeR2C);
-                                if (cuFFTErr != CUFFT_SUCCESS)
-                                    std::cerr << "cufftEstimate3d() failed. " << new_nz << " x " << new_ny << " x " << deskewedXdim << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
-
-                                std::cerr << "R2C FFT Plan desires " << workSizeR2C / (1024 * 1024) << " MB. " << std::endl;
-                                throw std::runtime_error("cufftMakePlan3d() r2c failed.");
-                            }
-
-                            cuFFTErr = cufftCreate(&rfftplanInvGPU);						// create object.
-                            if (cuFFTErr != CUFFT_SUCCESS)
-                                std::cerr << "cufftCreate(&rfftplanInvGPU) failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
-
-                            cuFFTErr = cufftSetAutoAllocation(rfftplanInvGPU, autoAllocate);
-                            if (cuFFTErr != CUFFT_SUCCESS)
-                                std::cerr << "cufftSetAutoAllocation(rfftplanInvGPU, autoAllocate) failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
-
-                            cuFFTErr = cufftMakePlan3d(rfftplanInvGPU, new_nz, new_ny, deskewedXdim, CUFFT_C2R, &workSizeC2R);// make plan, get workSize
-                            if (cuFFTErr != CUFFT_SUCCESS) {
-                                std::cerr << "cufftMakePlan3d() c2r failed. " << new_nz << " x " << new_ny << " x " << deskewedXdim << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
-                                cudaMemGetInfo(&GPUfree, &GPUtotal);
-                                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
-
-                                cuFFTErr = cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_C2R, &workSizeC2R);
-                                if (cuFFTErr != CUFFT_SUCCESS)
-                                    std::cerr << "cufftEstimate3d() failed. " << new_nz << " x " << new_ny << " x " << deskewedXdim << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
-
-                                std::cerr << "C2R FFT Plan desires " << workSizeC2R / (1024 * 1024) << " MB. " << std::endl;
-                                throw std::runtime_error("cufftMakePlan3d() c2r failed.");
-                            }
-
-                            if (workSizeC2R > workSizeR2C) {
-                                workSize = workSizeC2R;    // set workSize to max of C2R and R2C plans.
-                            }
-                            else {
-                                workSize = workSizeR2C;
-                            }
-
-                            if (workArea.getSize() != workSize) {  // do we need to (re)allocate workArea?
-                                workArea.resize(workSize);
-                                std::cout << "FFTplan workarea allctd.   (";
-                                cudaMemGetInfo(&GPUfree, &GPUtotal);
-                                std::cout << std::setw(4) << workArea.getSize() / (1024 * 1024) << "MB)" << std::setw(7) << GPUfree / (1024 * 1024) << "MB free " << std::endl;
-                            }
-
-                            cuFFTErr = cufftSetWorkArea(rfftplanGPU, workArea.getPtr());
-                            if (cuFFTErr != CUFFT_SUCCESS) {
-                                std::cerr << "cufftSetWorkArea() r2c failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
-                                cudaMemGetInfo(&GPUfree, &GPUtotal);
-                                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
-
-                                cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_R2C, &workSizeR2C);
-                                std::cerr << "R2C FFT Plan desires " << workSizeR2C / (1024 * 1024) << " MB. " << std::endl;
-                                throw std::runtime_error("cufftSetWorkArea() r2c failed.");
-                            }
-
-                            cuFFTErr = cufftSetWorkArea(rfftplanInvGPU, workArea.getPtr());
-                            if (cuFFTErr != CUFFT_SUCCESS) {
-                                std::cerr << "cufftSetWorkArea() c2r failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
-                                cudaMemGetInfo(&GPUfree, &GPUtotal);
-                                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
-
-                                cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_C2R, &workSizeC2R);
-                                std::cerr << "C2R FFT Plan desires " << workSizeC2R / (1024 * 1024) << " MB. " << std::endl;
-                                throw std::runtime_error("cufftSetWorkArea() c2r failed.");
-                            }
-
-                        } // end FFT plan allocation method (either normal way or "shared" plan way)
-
-                        std::cout << "FFT plans allocated.    ";
-                        cudaMemGetInfo(&GPUfree, &GPUtotal);
-                        std::cout << std::setw(8) << (GPUfree_prev - GPUfree) / (1024 * 1024) << "MB" << std::setw(8) << GPUfree / (1024 * 1024)
-                                  << "MB free" << " nz=" << new_nz << ", ny=" << new_ny << ", nx=" << deskewedXdim << std::endl;
-
-                    }  //else if (RL_iters>0)
-
-                    //****************Transfer a bunch of constants to device, including OTF array:*******************
-
-                    dkx = 1.0/(imgParams.dr * deskewedXdim);
-                    dky = 1.0/(imgParams.dr * new_ny);
-
-                    unsigned nz_const;
-                    if (bDupRevStack)
-                        nz_const = new_nz*2;
-                    else
-                        nz_const = new_nz;
-                    dkz = 1.0/(imgParams.dz * nz_const);
-
-                    rdistcutoff = 2*NA/(imgParams.wave); // lateral resolution limit in 1/um
-                    float eps = std::numeric_limits<float>::epsilon();
-
-                    transferConstants(deskewedXdim, new_ny,
-                                      nz_const,
-                                      complexOTF.height(), complexOTF.width()/2,
-                                      dkx/dkr_otf, dky/dkr_otf, dkz/dkz_otf,
-                                      eps, complexOTF.data());
-
-                    d_interpOTF.resize(nz_const * new_ny * (deskewedXdim+2) * sizeof(float)); // allocate memory
-                    makeOTFarray(d_interpOTF, deskewedXdim, new_ny, nz_const); // interpolate.  This reads from the complexOTF.data sent to the GPU from transferConstants().
-                    std::cout << "d_interpOTF allocated.  ";
-                    cudaMemGetInfo(&GPUfree, &GPUtotal);
-                    std::cout << std::setw(8) << d_interpOTF.getSize() / (1024 * 1024) << "MB" << std::setw(8) << GPUfree / (1024 * 1024) << "MB free" << std::endl;
-
-                    //****************************Prepare Light Sheet Correction if desired ***********************
-
-                    if (LSfile.size()) {
-
-                        const float my_min = 0.2;
-
-                        std::cout << std::endl << "Loading LS Correction      : ";
-                        LSImage.assign(LSfile.c_str());
-                        std::cout << LSImage.width() << " x " << LSImage.height() << " x " << LSImage.depth() << ". " << std::endl;
-                        AverageLS.resize(LSImage.width(), LSImage.height(), 1, 1, -1); //Set size of AverageLS
-                        AverageLS.fill(0); //fill with zeros
-
-                        cimg_forXYZ(LSImage, x, y, z) {
-                            AverageLS(x, y) = AverageLS(x, y) + LSImage(x, y, z); //sum image
-
-                            if (z == (LSImage.depth() - 1)) // if this is the last Z slice
-                                AverageLS(x, y) = AverageLS(x, y) / LSImage.depth(); //divide by number of slices
-                        }
-
-                        const int LSIx = AverageLS.width();
-                        const int LSIy = AverageLS.height();
-
-                        int LSIborderx = (LSIx - nx) / 2;
-                        int LSIbordery = (LSIy - ny) / 2;
-
-                        std::cout << "Excess LS border to crop   : " << LSIborderx << " x " << LSIbordery << std::endl;
-
-                        AverageLS.crop(LSIborderx, LSIbordery, LSIx - LSIborderx - 1, LSIy - LSIbordery - 1); //crop it
-
-                        cimg_forXY(AverageLS, x, y)
-                        AverageLS(x, y) = AverageLS(x, y) - background;
-
-
-                        img_max = AverageLS(0, 0);
-                        img_min = AverageLS(0, 0);
-                        cimg_forXY(AverageLS, x, y) {
-                            img_max = std::max(AverageLS(x, y), img_max);
-                            img_min = std::min(AverageLS(x, y), img_min);
-                        }
-                        std::cout << "               LS max, min : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
-
-                        const float normalization = img_max;
-
-                        img_max = -9999999;
-                        img_min = 9999999;
-                        cimg_forXY(AverageLS, x, y) {
-                            AverageLS(x, y) = AverageLS(x, y) / normalization;
-                            img_max = std::max(AverageLS(x, y), img_max);
-                            img_min = std::min(AverageLS(x, y), img_min);
-                        }
-                        std::cout << "       After normalization : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
-
-
-                        AverageLS.max(my_min); // set everything below 0.2 to 0.2.  This will prevent divide by zero.
-                    } // end if (LSfile.size())
-
-                } // end if (nx == 0 || bDifferent_sized_raw_img )
-
-                //****************************Apply Light Sheet Correction if desired ***********************
-                if (LSfile.size()) {
-                    CImg<float> Temp(raw_image); // Copy raw_image to a floating point image
-
-                    cimg_forXYZ(Temp, x, y, z)
-                    Temp(x, y, z) = Temp(x, y, z) - background; // subtract background. min value =0.
-
-                    Temp.max((float)0); // set min value to 0.  have to cast zero to avoid compiler complaint.
-
-                    if (it == all_matching_files.begin()) {
-                        img_max = AverageLS(0, 0);
-                        img_min = AverageLS(0, 0);
-
-                        cimg_forXY(AverageLS, x, y) {
-                            img_max = std::max(AverageLS(x, y), img_max);
-                            img_min = std::min(AverageLS(x, y), img_min);
-                        }
-                        std::cout << "LSC size                   : " << AverageLS.width() << " x " << AverageLS.height() << " x " << AverageLS.depth() << std::endl;
-                        std::cout << "LSC max, min               : " << img_max << ", " << img_min << std::endl;
-                    }
-
-                    std::cout << "Dividing by LSC... ";
-
-                    Temp.div(AverageLS);
-                    std::cout << " Done." << std::endl;
-
-                    cimg_forXYZ(Temp, x, y, z)
-                    raw_image(x, y, z) = Temp(x, y, z) + background; //replace background and copy back to U16 raw_image.
-                } // end if applying LS correction
-
-				voxel_size[0] = imgParams.dr;
-				voxel_size[1] = imgParams.dr;
-				voxel_size[2] = imgParams.dz;
-                imdz = imgParams.dz;
-                if (rotMatrix.getSize()) {
-                    imdz = imgParams.dr;
-                }
-				voxel_size_decon[0] = imgParams.dr;
-				voxel_size_decon[1] = imgParams.dr;
-				voxel_size_decon[2] = imdz;
-                std::string s = "ImageJ=1.50i\n"
-                                "spacing=" + std::to_string(imgParams.dz) + "\n"
-                                "unit=micron";
-                description = s.c_str();
-
-                //****************************Pad image.  Use Mirror image in padded border region***********************************
-
-                if (Pad) {
-                    border_x = (new_nx - nx) / 2;   // get border size
-                    border_y = (new_ny - ny) / 2;
-                    border_z = (new_nz - nz) / 2;
-
-                    std::cout << std::endl <<  "Create padded img.  Border : " << border_x << " x " << border_y << " x " << border_z << ". " << std::endl;
-                    CImg<> raw_original(raw_image);       //copy from raw image
-                    std::cout << "Image with padding size    : " << new_nx << " x " << new_ny << " x " << new_nz << ". ";
-                    raw_image.resize(new_nx, new_ny, new_nz);     //resize with border
-
-                    int x_raw;
-                    int y_raw;
-                    int z_raw;
-
-                    int i_nx = (int)nx;
-                    int i_ny = (int)ny;
-                    int i_nz = (int)nz;
-
-                    // std::cout << "Line:" << __LINE__ << std::endl;
-                    std::cout << "Copy values... ";
-                    cimg_forXYZ(raw_image, x, y, z) // for every pixel in the new image, copy value from original image
-                    {
-                        x_raw = abs(x - border_x);
-                        y_raw = abs(y - border_y);
-                        z_raw = abs(z - border_z);
-
-                        if (x_raw >= i_nx)
-                            x_raw = i_nx - (x_raw - i_nx) - 1;
-
-                        if (y_raw >= i_ny)
-                            y_raw = i_ny - (y_raw - i_ny) - 1;
-
-                        if (z_raw >= i_nz)
-                            z_raw = i_nz - (z_raw - i_nz) - 1;
-
-                        //raw_image(x, y, z) = x_raw;
-                        raw_image(x, y, z) = raw_original(x_raw, y_raw, z_raw);
-                    }
-                    //***debug padded image.
-                    if (false) {
-                        std::cout << "Saving padded image... " << std::endl;
-                        makeNewDir("Padded");
-                        CImg<unsigned short> uint16Img(raw_image);
-                        uint16Img.save_tiff(makeOutputFilePath(*it, "Padded", "_padded").c_str(), 0, voxel_size, description);
-                    }
-                    std::cout << "Done." << std::endl;
-                } // End Pad image creation.
-
-                // moved here from boostfs.cpp in order to make it conditional on actually performing decon
-                // this MAY cause some bugs ... but haven't seen any since adding a long time ago
-                if (RL_iters || rotMatrix.getSize()) {
-                    if (it == all_matching_files.begin()) //make directory only on first call, and if we are saving Deskewed.
-                        makeNewDir("GPUdecon");
-                }
-
-                // initialize the raw_deskewed size everytime in case it is cropped on an earlier iteration
-                if (bSaveDeskewedRaw && (fabs(deskewAngle) > 0.0) ) {
-                    raw_deskewed.assign(deskewedXdim, new_ny, new_nz);
-
-                    if (it == all_matching_files.begin() + skip) //make directory only on first call, and if we are saving Deskewed.
-                        makeNewDir("Deskewed");
-                }
-
-                // If deskew is to happen, it'll be performed inside RichardsonLucy_GPU() on GPU;
-                // but here raw data's x dimension is still just "new_nx"
-                if (bCrop)
-                    raw_image.crop(0, 0, 0, 0, new_nx-1, new_ny-1, new_nz-1, 0);
-
-                if (wiener >0) { // plain 1-step Wiener filtering
-                    raw_image -= background;
-                    fftwf_execute_dft_r2c(rfftplan, raw_image.data(), (fftwf_complex *) raw_imageFFT.data());
-
-                    wienerfilter(raw_imageFFT,
-                                 dkx, dky, dkz,
-                                 complexOTF,
-                                 dkr_otf, dkz_otf,
-                                 rdistcutoff, wiener);
-
-                    fftwf_execute_dft_c2r(rfftplan_inv, (fftwf_complex *) raw_imageFFT.data(), raw_image.data());
-                    raw_image /= raw_image.size();
-                }
-                else if (RL_iters || raw_deskewed.size() || rotMatrix.getSize()) {
-                    #ifndef NDEBUG
-                    img_max = raw_image(0, 0, 0);
-                    img_min = raw_image(0, 0, 0);
-                    cimg_forXYZ(raw_image, x, y, z) {
-                        img_max = std::max(raw_image(x, y, z), img_max);
-                        img_min = std::min(raw_image(x, y, z), img_min);
-                    }
-                    std::cout << "RL_image : " << raw_image.width() << " x " << raw_image.height() << " x " << raw_image.depth() << ". " << std::endl;
-                    std::cout << "         RL_image max, min : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
-                    #endif
-                    float my_median = 1;
-                    if (bFlatStartGuess)
-                        my_median = raw_image.median();
-
-                    #ifdef USE_NVTX
-                    cudaProfilerStart();
-                    #endif
-
-                    //************************************************************************************
-                    //****************************Run RL GPU**********************************************
-                    //************************************************************************************
-                    RichardsonLucy_GPU(raw_image, background, d_interpOTF, RL_iters, deskewFactor,
-                                       deskewedXdim, extraShift, napodize, nZblend, rotMatrix,
-                                       rfftplanGPU, rfftplanInvGPU, raw_deskewed, &deviceProp,
-                                       bFlatStartGuess, my_median, bDoRescale, padVal, bDupRevStack,
-                                       UseOnlyHostMem, myGPUdevice);
-                    #ifdef USE_NVTX
-                    cudaProfilerStop();
-                    #endif
-                }
-                else {
-                    std::cerr << "Nothing is performed\n";
-                }
-
-                #ifndef NDEBUG
-                img_max = raw_image(0, 0, 0);
-                img_min = raw_image(0, 0, 0);
-                cimg_forXYZ(raw_image, x, y, z) {
-                    img_max = std::max(raw_image(x, y, z), img_max);
-                    img_min = std::min(raw_image(x, y, z), img_min);
-                }
-                std::cout << "output_image : " << raw_image.width() << " x " << raw_image.height() << " x " << raw_image.depth() << ". " << std::endl;
-                std::cout << "         output_image max, min : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
-                #endif
-
-                //****************************Stitch tiles***********************************
-
-                if (number_of_tiles > 1) { // are we tiling?
-
-                    if (tile_index == 0) {
-                        stitch_image.assign(raw_image.width(), file_image.height(), raw_image.depth()); // initialize destination stitch_image.
-                        std::cout << "         stitch_image : " << stitch_image.width() << " x " << stitch_image.height() << " x " << stitch_image.depth() << ". " << std::endl;
-                        stitch_image.fill((float)0.0);
-
-                        blend_weight_image.assign(raw_image.width(), file_image.height(), raw_image.depth()); // initialize destination blend_weight_image.
-                        blend_weight_image.fill(0);
-                    }
-                    // int no_zone    = floor((float)tile_overlap / 3) ;  // 1/3 no_zone, 1/3 blend zone, 1/3 no_zone
-                    int no_zone    = ceil((tile_overlap - 4) / 2.0) ;  //  no_zone, 4 pixel blend zone, yes_zone
-                    int blend_zone = tile_overlap - no_zone - no_zone;
-
-                    std::cout << "           tile_image : " << raw_image.width() << " x " << raw_image.height() << " x " << raw_image.depth() << ". tile_overlap: " << tile_overlap << ". blend_zone: " << blend_zone << ". tile_y_offset:" << tile_y_offset << ". " << std::endl;
-                    bool is_first_tile = tile_index == 0;
-                    bool is_last_tile = tile_index + 1 >= number_of_tiles;
-
-                    cimg_forXYZ(raw_image, x, y, z) {
-                        float blend = 1;
-
-                        if (is_first_tile && y <= tile_overlap)
-                            blend = 1;// front overlap region of 1st tile
-                        else if (is_last_tile && y >= raw_image.height() - tile_overlap )
-                            blend = 1;// back overlap region of last tile
-                        else {
-                            if (y <= no_zone) // front no_zone?
-                                blend = 0;
-
-                            else if(y > no_zone && y <= no_zone + blend_zone) // front blend region?
-                                blend = (double)(y - no_zone) / blend_zone;
-
-                            else if (y >= raw_image.height() - no_zone) // back no zone?
-                                blend = 0;
-
-                            else blend = 1; // middle zone or back blend zone
-                        }
-
-                        if (y + tile_y_offset < stitch_image.height()) { /* are we inside of the destination image?*/
-
-                            if (BlendTileOverlap) { // blend the overlap?
-                                if (blend > 0 && blend < 1 && blend_weight_image(x, y + tile_y_offset, z) > 0) { // need to blend?
-                                    stitch_image(x, y + tile_y_offset, z) = (raw_image(x, y, z) * blend) + (stitch_image(x, y + tile_y_offset, z) * (1.0 - blend)); // insert into image with blend in overlap region
-                                    //stitch_image(x, y + tile_y_offset, z) = blend * 1000;
-                                }
-
-                                else if (blend > 0 && blend_weight_image(x, y + tile_y_offset, z) == 0) // just put this pixel into the image
-                                    stitch_image(x, y + tile_y_offset, z) = raw_image(x, y, z);
-
-                                else if (blend == 1)
-                                    stitch_image(x, y + tile_y_offset, z) = raw_image(x, y, z); // just put this pixel into the image
-
-                                if (blend > 0)
-                                    blend_weight_image(x, y + tile_y_offset, z) = 1;
-                            }
-                            else // overlap is either 1 tile or the other.
-                            {
-                                bool is_past_front_overlap = (y >= floor((float)tile_overlap / 2.0) || is_first_tile);
-                                bool is_before_end_overlap = (y < floor(raw_image.height() - (float)tile_overlap / 2.0) || is_last_tile);
-
-                                if (is_past_front_overlap && is_before_end_overlap)
-                                    stitch_image(x, y + tile_y_offset, z) = raw_image(x, y, z); // insert into image directly without blend in overlap region
-                            }
-                        }
-
-                    } // end loop on pixels
-                } // end if (number_of_tiles > 1)
-                else
-                    stitch_image.assign(raw_image, false); // no tiling, so just do image copy.
-
-            } // end for (int tile_index = 0; ... ) tiling loop
-
-            //****************************Crop***********************************
-
-            //remove padding
-            if (Pad)
-                stitch_image.crop(
-                    border_x, border_y,         	// X, Y
-                    border_z, 0,			        // Z, C
-                    border_x + nx, border_y + ny,	// X, Y
-                    border_z + nz, 0);			    // Z, C
-
-            if (! final_CropTo_boundaries.empty()) {
-                stitch_image.crop(final_CropTo_boundaries[0], final_CropTo_boundaries[2],   // X, Y
-                                  final_CropTo_boundaries[4], 0,							// Z, C
-                                  final_CropTo_boundaries[1], final_CropTo_boundaries[3],	// X, Y
-                                  final_CropTo_boundaries[5], 0);							// Z, C
-                if (raw_deskewed.size()) {
-                    // std::cout << std::endl << "The 'raw_deskewed' buffer uses " << raw_deskewed.size()*sizeof(float) << " bytes." << std::endl;
-                    raw_deskewed.crop(final_CropTo_boundaries[0], final_CropTo_boundaries[2],
-                                      final_CropTo_boundaries[4], 0,
-                                      final_CropTo_boundaries[1], final_CropTo_boundaries[3],
-                                      final_CropTo_boundaries[5], 0);
-                }
-            }
-
-            if (tsave.joinable()) {
-                tsave.join();           // wait for previous saving thread to finish.
-                tsave.~thread();        // destroy thread.
-            }
-
-            if (tDeskewsave.joinable()) {
-                tDeskewsave.join();     // wait for previous saving thread to finish.
-                tDeskewsave.~thread();  // destroy thread.
-            }
-
-
-            //****************************Save Deskewed Raw***********************************
-            if (bSaveDeskewedRaw && (fabs(deskewAngle) > 0.0)) {
-                if (!bSaveUshort) {
-                    DeskewedToSave.assign(raw_deskewed);
-                    tDeskewsave = std::thread(DeSkewsave_in_thread, *it, voxel_size, description); //start saving "Deskewed To Save" file.
-                    //raw_deskewed.save_tiff(makeOutputFilePath(*it, "Deskewed", "_deskewed").c_str(), 0, voxel_size, description);
-                }
-                else {
-                    CImg<unsigned short> uint16Img(raw_deskewed);
-                    uint16Img.save_tiff(makeOutputFilePath(*it, "Deskewed", "_deskewed").c_str(), compression, voxel_size, description);
-                }
-            }
-
-
-            //****************************Save Deskewed MIPs***********************************
-            if (bDoRawMaxIntProj.size() == 3 && bSaveDeskewedRaw) {
-                if(it == all_matching_files.begin() && (bDoRawMaxIntProj[0] || bDoRawMaxIntProj[1] || bDoRawMaxIntProj[2]))
-                    makeNewDir("Deskewed/MIPs");
-
-                if (bDoRawMaxIntProj[0]) {
-                    CImg<> proj = MaxIntProj(raw_deskewed, 0);
-                    proj.save_tiff(makeOutputFilePath(*it, "Deskewed/MIPs", "_MIP_x").c_str(), compression, voxel_size, description);
-                }
-                if (bDoRawMaxIntProj[1]) {
-                    CImg<> proj = MaxIntProj(raw_deskewed, 1);
-                    proj.save_tiff(makeOutputFilePath(*it, "Deskewed/MIPs", "_MIP_y").c_str(), compression, voxel_size, description);
-                }
-                if (bDoRawMaxIntProj[2]) {
-                    CImg<> proj = MaxIntProj(raw_deskewed, 2);
-                    proj.save_tiff(makeOutputFilePath(*it, "Deskewed/MIPs", "_MIP_z").c_str(), compression, voxel_size, description);
-                }
-
-            }
-
-            //****************************Save MIPs***********************************
-
-            // I had to modify this a bit to save the behavior of --saveDeskewedRaw when NO RL is being performed...
-            // otherwise, it was trying to create folders it shouldn't...
-            // this might have unintended side effects (notably with weiner filtering only... and maybe others)
-            if (bDoMaxIntProj.size() == 3 && RL_iters && (bDoMaxIntProj[0] || bDoMaxIntProj[1] || bDoMaxIntProj[2])) {
-                if (it == all_matching_files.begin() + skip) {
-                    makeNewDir("GPUdecon/MIPs");
-                }
-
-                if (bDoMaxIntProj[0]) {
-                    CImg<> proj = MaxIntProj(stitch_image, 0);
-                    if (bSaveUshort) {
-                        CImg<unsigned short> uint16Img(proj);
-                        uint16Img.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_x").c_str(), compression, voxel_size, description);
-                    }
-                    else
-                    {
-                        proj.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_x").c_str(), compression, voxel_size, description);
-                    }
-                }
-                if (bDoMaxIntProj[1]) {
-                    CImg<> proj = MaxIntProj(stitch_image, 1);
-                    if (bSaveUshort) {
-                        CImg<unsigned short> uint16Img(proj);
-                        uint16Img.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_y").c_str(), compression, voxel_size, description);
-                    }
-                    else
-                    {
-                        proj.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_y").c_str(), compression, voxel_size, description);
-                    }
-                }
-                if (bDoMaxIntProj[2]) {
-                    CImg<> proj = MaxIntProj(stitch_image, 2);
-                    if (bSaveUshort) {
-                        CImg<unsigned short> uint16Img(proj);
-                        uint16Img.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_z").c_str(), compression, voxel_size, description);
-                    }
-                    else
-                    {
-                        proj.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_z").c_str(), compression, voxel_size, description);
-                    }
-                }
-            }
-
-            //****************************Save Decon Image***********************************
-            if (RL_iters || rotMatrix.getSize()) {
-                // Stupid to redefine these here... but couldn't get the Z voxel size to work
-                // correctly in ImageJ otherwise...
-
-                if (!bSaveUshort) {
-
-                    ToSave.assign(stitch_image); //copy decon image (i.e. stitch_image) to new image space for saving.
-                    // ToSave.save_tiff(makeOutputFilePath(*it).c_str(), compression, voxel_size, description);
-
-                    tsave = std::thread(save_in_thread, *it, voxel_size_decon, imdz); //start saving "To Save" file.
-                }
-                else {
-                    U16ToSave = stitch_image;
-                    tsave = std::thread(U16save_in_thread, *it, voxel_size_decon, imdz); //start saving "To Save" file.
-                }
-            }
-
-            /// please leave this here for LLSpy
-            printf(">>>file_finished\n");
-
-            iter_duration = (std::clock() - start_t) / (double)CLOCKS_PER_SEC / (it - (all_matching_files.begin() + skip) + 1 );
-        } // end for (std::vector<std::string>::iterator it= all_matching_files.begin() + skip;
-
-        if (tsave.joinable()) {
-            tsave.join();               // wait for previous saving thread to finish.
-            tsave.~thread();            // destroy thread.
-        } //Make sure we have finished saving.
-
-        if (tDeskewsave.joinable()) {
-            tDeskewsave.join();         // wait for previous saving thread to finish.
-            tDeskewsave.~thread();      // destroy thread.
-        } //Make sure we have finished saving.
-
-        duration = (std::clock() - start_t) / (double)CLOCKS_PER_SEC;
-
-        #ifdef _WIN32
-        SetConsoleTextAttribute(hConsole, 10); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-        #endif
-        std::cout << "*** Finished! Elapsed " << duration << " seconds.  ";
-        if (skip != 0)
-            std::cout << "Skipped " << skip << "images.  ";
-        std::cout << "Processed " << all_matching_files.size() - skip << " images.  " << duration / all_matching_files.size() << " seconds per image. ***" << std::endl;
-        #ifdef _WIN32
-        SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
-        #endif
-
-    } // end try {} block
-    catch (std::exception &e) {
-        std::cerr << "\n!!Error occurred: " << e.what() << std::endl;
-        return 0;
+      return 0; // added return because I want query to simply query and quit
     }
+
+    notify(varsmap);
+
+    // if (varsmap.count("crop")) {
+    //   if (final_CropTo_boundaries.size() != 6)
+    //     throw std::runtime_error("Exactly 6 integers are required for the -C or --crop flag!");
+    //   std::copy(final_CropTo_boundaries.begin(), final_CropTo_boundaries.end(), std::ostream_iterator<int>(std::cout, ", "));
+    //   std::cout << std::endl;
+    // }
+    // std::cout << bDoMaxIntProj.size() << std::endl;
+  }
+  catch (std::exception &e) {
+    std::cout << "\n!!Error occurred: " << e.what() << std::endl;
     return 0;
+  }
+
+  bool bAdjustResolution = !bDontAdjustResolution;
+  imgParamsOld = imgParams; // Copy image Params
+
+  //****************************Check to see if we have a proper GPU device***********************************
+  int deviceCount = 0;
+  cudaError_t error_id = cudaGetDeviceCount(&deviceCount);
+  if (error_id != cudaSuccess)
+    {
+      printf("cudaGetDeviceCount returned %d\n-> %s\n", (int)error_id, cudaGetErrorString(error_id));
+      printf("Result = FAIL\n");
+      exit(EXIT_FAILURE);
+    }
+  if (deviceCount == 0)
+    printf("There are no available device(s) that support CUDA\n");
+
+
+  cudaSetDeviceFlags(cudaDeviceMapHost);
+  size_t GPUfree;
+  size_t GPUtotal;
+  cudaMemGetInfo(&GPUfree, &GPUtotal);
+  cudaDeviceProp mydeviceProp;
+  cudaGetDeviceProperties(&mydeviceProp, myGPUdevice);
+
+#ifdef _WIN32
+  SetConsoleTextAttribute(hConsole, 13); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+
+  std::cout << std::endl << "Built : " << __DATE__ << " " << __TIME__ << ".  GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total on " << mydeviceProp.name << std::endl;
+
+  CImg<> raw_image, raw_imageFFT, complexOTF, raw_deskewed, LSImage, sub_image, file_image, stitch_image, blend_weight_image;
+  CImg<float> AverageLS;
+  float dkx_otf, dky_otf, dkz_otf;
+  float dkx, dky, dkz, rdistcutoff;
+  fftwf_plan rfftplan=NULL, rfftplan_inv=NULL;
+  CPUBuffer rotMatrix;
+  double deskewFactor=0;
+  bool bCrop = false;
+  unsigned new_ny, new_nz, new_nx;
+  int deskewedXdim = 0;
+  cufftHandle rfftplanGPU = NULL, rfftplanInvGPU = NULL;
+  GPUBuffer d_interpOTF(myGPUdevice, UseOnlyHostMem);
+  GPUBuffer d_rawOTF(myGPUdevice, UseOnlyHostMem);
+  GPUBuffer workArea(myGPUdevice, UseOnlyHostMem);
+  // why were the above GPUBuffer()'s called with "1" as the first parameter ("size")??
+
+  cudaDeviceProp deviceProp;
+  cudaGetDeviceProperties(&deviceProp, myGPUdevice);
+
+  unsigned nx, ny, nz = 0;
+
+  int border_x = 0;
+  int border_y = 0;
+  int border_z = 0;
+
+  float voxel_size [3];
+  float voxel_size_decon [3];
+  float imdz;
+  const char *description;
+
+  if (lzw) {
+    compression = 1;
+  }
+  //****************************Main processing***********************************
+  // Loop over all matching input TIFFs, :
+  try {
+
+
+    std::cout << "Looking for files to process... " ;
+    // Gather all files in 'datafolder' and matching the file name pattern:
+    //bool MIPsOnly = (RL_iters == 0 && bDoMaxIntProj.size() == 3);
+
+    std::vector< std::string > all_matching_files = gatherMatchingFiles(datafolder, filenamePattern, no_overwrite);
+    std::cout << "Found " << all_matching_files.size() << " file(s)." << std::endl ;
+
+#ifdef _WIN32
+    SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+    if (all_matching_files.size() == 0) {
+#ifdef _WIN32
+      SetConsoleTextAttribute(hConsole, 10); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+      std::cout<< "\nNo files need processing!" << std::endl;
+#ifdef _WIN32
+      SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+      return 0;
+    }
+
+
+    std::vector<std::string>::iterator next_it = all_matching_files.begin() + skip;//make a second incrementer that will be used to load the next raw image while we process.
+
+    std::thread t1; // thread for loading files
+    t1 = std::thread(load_next_thread, next_it->c_str());   //start loading the first file.
+
+    std::thread tsave;  // thread for saving decon
+    std::thread tDeskewsave; // thread for saving deskewed
+
+    for (std::vector<std::string>::iterator it= all_matching_files.begin() + skip;
+         it != all_matching_files.end(); it++) {
+
+      int number_of_files_left = all_matching_files.end() - it;
+
+#ifdef _WIN32
+      SetConsoleTextAttribute(hConsole, 10); // colors are 9=blue 10=green and so on to 15=white
+#endif
+      std::cout << std::endl << "Loading raw_image: " << it - all_matching_files.begin() + 1 << " out of " << all_matching_files.size() << ".   ";
+      if (it > all_matching_files.begin() + skip) // if this isn't the first iteration.
+        {
+          int seconds = number_of_files_left * iter_duration;
+          int hours = ceil(seconds / (60 * 60));
+          int minutes = ceil((seconds - (hours * 60 * 60)) / 60);
+          std::cout << (int)iter_duration << " s/file.   " << number_of_files_left << " files left.  " << hours << " hours, " <<  minutes << " minutes remaining.";
+        }
+
+      std::cout <<  std::endl;
+#ifdef _WIN32
+      SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+
+      std::cout << std::endl << *it << std::endl;
+      std::cout << "Waiting for separate thread to finish loading image... " ;
+      t1.join();        // wait for loading thread to finish reading next_raw_image into memory.
+      t1.~thread();     // destroy thread.
+      std::cout << "Image loaded. Copying to 'file_image'... " ;
+      file_image.assign(next_file_image, false); // Copy to file_image.  CImg<T>& assign(const CImg<t>& img, const bool is_shared)
+
+      float img_max = file_image(0, 0);
+      float img_min = file_image(0, 0);
+
+#ifndef NDEBUG
+      cimg_forXYZ(file_image, x, y, z) {
+        img_max = std::max(file_image(x, y, z), img_max);
+        img_min = std::min(file_image(x, y, z), img_min);
+      }
+
+      std::cout << "         raw img max, min : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
+#endif
+
+
+
+      std::cout << "Done." << std::endl;
+
+      // start reading the next image
+      next_it++; // increment next_it.  This will now have the next file to read.
+      if (it < all_matching_files.end() - 1)  // If there are more files to process...
+        t1 = std::thread(load_next_thread, next_it->c_str());       //start new thread and load the next file, while we process file_image
+
+      //**************************** Tiling setup ***********************************
+      int number_of_tiles = 1;
+      int number_of_overlaps = 0;
+      double tile_overlap = 0;
+
+
+      if (tile_requested < 0) {
+        tile_size = std::min(           128, file_image.height());
+      }
+      if (tile_requested > 0) {
+        tile_size = std::min(tile_requested, file_image.height());
+      }
+
+      number_of_tiles = ceil((double)file_image.height() / ((double)tile_size - tile_overlap_requested)); // try for 20 pixel overlap
+      number_of_overlaps = number_of_tiles - 1;
+      tile_overlap = (((double)tile_size * number_of_tiles) - file_image.height()) / number_of_overlaps;
+      tile_overlap = floor(tile_overlap); //
+
+
+      if (tile_requested == 0) {
+        number_of_tiles = 1;
+        tile_size = file_image.height();
+        tile_overlap = 0;
+        number_of_overlaps = 0;
+      }
+      std::cout << std::endl << "# of tiles: " << number_of_tiles << ". # of overlaps: " << number_of_overlaps << ". Tile size: " << tile_size << " Y pix. Overlap: " << tile_overlap << " Y pix. " << std::endl;
+
+      for (int tile_index = 0; tile_index < number_of_tiles; tile_index++) {
+        int tile_y_offset = floor( (double)tile_index*(tile_size - tile_overlap) );
+        //std::cout << std::endl << "tile_y_offset: " << tile_y_offset;
+
+        if (number_of_tiles > 1) {
+
+          //int y_end = std::min(file_image.height(), tile_size + tile_y_offset);
+          int y_end = tile_size + tile_y_offset; // I think we can crop to outside the image, and the boundry conditions will fill it. This way each subimage is exactly the same size, which makes the rest of the code mighty happy.
+
+
+          raw_image = file_image.get_crop(0,  /* X start */
+                                          tile_y_offset,                  /* Y start */
+                                          0,                              /* Z start */
+                                          file_image.width() - 1,         /*  X end */
+                                          y_end - 1,                      /*  Y end */
+                                          file_image.depth() - 1,         /*  Z end */
+                                          true); // get sub_image. raw_image = sub_image
+
+
+          //for (int y = tile_y_offset; y < y_end; ++y) {
+
+          //cimg_forXZ(file_image, x, z) {
+          //raw_image(x, y_raw_index, z) = (unsigned long) file_image(x, y, z);
+          //}
+          //y_raw_index = y_raw_index + 1;
+          //}
+          //raw_image = file_image.get_crop(0,
+          //  tile_y_offset,
+          //  0,
+          //  0,
+          //  file_image.width() - 1,
+          //  std::min(file_image.height(), tile_size + tile_y_offset) - 1,
+          //  file_image.depth() - 1,
+          //  0); // get sub_image. raw_image = sub_image
+#ifdef _WIN32
+          SetConsoleTextAttribute(hConsole, 10); // colors are 9=blue 10=green and so on to 15=white
+#endif
+          std::cout << std::endl << "Tile: " << tile_index + 1 << " out of " << number_of_tiles << ".   " << std::endl;
+#ifdef _WIN32
+          SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+          // raw_image.save(makeOutputFilePath(it->c_str(), "tile", "_tile").c_str()); //for debugging
+        }
+        else
+          raw_image.assign(file_image);
+
+        // If it's the first input file, initialize a bunch including:
+        // 1. crop image to make dimensions nice factorizable numbers
+        // 2. calculate deskew parameters, new X dimensions
+        // 3. calculate rotation matrix
+        // 4. create FFT plans
+        // 5. transfer constants into GPU device constant memory
+        // 6. make 3D OTF array in device memory
+
+        bool bDifferent_sized_raw_img = (nx != raw_image.width() || ny != raw_image.height() || nz != raw_image.depth() ); // Check if raw.image has changed size from first iteration
+
+        if (it != all_matching_files.begin() + skip && bDifferent_sized_raw_img) {
+#ifdef _WIN32
+          SetConsoleTextAttribute(hConsole, 14); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+          std::cout << std::endl << "File " << it - all_matching_files.begin() + 1 << " has a different size" << std::endl;
+        }
+        std::cout << "raw_image size             : " << raw_image.width() << " x " << raw_image.height() << " x " << raw_image.depth() << std::endl;
+#ifdef _WIN32
+        SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+
+
+        //**************************** If first image OR if raw_img has changed size ***********************************
+        if (nx == 0 || bDifferent_sized_raw_img ) {
+          nx = raw_image.width();
+          ny = raw_image.height();
+          nz = raw_image.depth();
+          imgParams = imgParamsOld;
+
+
+
+          //****************************Adjust resolution if desired***********************************
+
+          int step_size;
+
+          if (fabs(deskewAngle) > 0.0 || fabs(rotationAngle) > 0.0)
+            {
+              Pad = 0;    // Currently padding is disabled if we are deskewing or rotating.
+              std::cout << "Currently padding is disabled if we are deskewing or rotating." << std::endl;
+            }
+
+          if (Pad)
+            step_size =  1;
+          else
+            step_size = -1;
+
+          int startnx = nx;
+          int startny = ny;
+          int startnz = nz;
+
+          if (Pad) { //pad by N number of border pixels
+            startnx = startnx + Pad * 2;
+            startny = startny + Pad * 2;
+            startnz = startnz + Pad * 2;
+            std::cout << "Min padding to use is " << Pad << " pixels." << std::endl;
+          }
+
+          if (RL_iters > 0 && (bAdjustResolution || Pad)) {
+            new_ny = findOptimalDimension(startny, step_size);
+            if (new_ny != startny) {
+              printf("new ny=%d\n", new_ny);
+              bCrop = true;
+            }
+
+            new_nz = findOptimalDimension(startnz, step_size);
+            if (new_nz != startnz) {
+              printf("new nz=%d\n", new_nz);
+              bCrop = true;
+            }
+
+            // only if no deskewing is happening before decon do we want to change image width here
+            new_nx = startnx;
+            if (!(fabs(deskewAngle) > 0.0) || bSkewedDecon) {
+              new_nx = findOptimalDimension(startnx, step_size);
+              if (new_nx != startnx) {
+                printf("new nx=%d\n", new_nx);
+                bCrop = true;
+              }
+            }
+          }
+          else {
+            new_nx = nx;
+            new_ny = ny;
+            new_nz = nz;
+          }
+
+
+          //****************************Load OTF to CPU RAM(assuming 3D rotationally averaged OTF)***********************************
+          std::cout <<  "Loading OTF... ";
+          complexOTF.assign(otffiles.c_str());
+          unsigned nx_otf, ny_otf, nz_otf;
+
+          if (bSkewedDecon && fabs(deskewAngle) > 0.0)
+            dz_psf *= fabs(sin(deskewAngle * M_PI/180.));
+
+          determine_OTF_dimensions(complexOTF, dr_psf, dz_psf,
+                                   nx_otf, ny_otf, nz_otf,
+                                   dkx_otf, dky_otf, dkz_otf);
+          std::cout << "nx x ny x nz     : " << nx_otf << " x " << ny_otf << " x " << nz_otf << ". " << std::endl << std::endl ;
+          // transfer raw OTF into device memory; texture TO-DO
+          d_rawOTF.resize(nx_otf * ny_otf * nz_otf * sizeof(cuFloatComplex));
+          cutilSafeCall(cudaMemcpy(d_rawOTF.getPtr(),complexOTF.data(),
+                                   d_rawOTF.getSize(), cudaMemcpyDefault));
+
+          //****************************Construct deskew matrix***********************************
+          deskewedXdim = new_nx;
+          if (fabs(deskewAngle) > 0.0) {
+            float old_dz = imgParams.dz;
+            if (deskewAngle <0) deskewAngle += 180.;
+            deskewFactor = cos(deskewAngle * M_PI/180.) * imgParams.dz / imgParams.dr;
+            if (outputWidth ==0)
+              deskewedXdim += floor(new_nz * imgParams.dz *
+                                    fabs(cos(deskewAngle * M_PI/180.)) / imgParams.dr);
+            // TODO: sometimes deskewedXdim calc'ed this way is too large
+            else
+              deskewedXdim = outputWidth; // use user-provided output width if available
+
+            // Adjust resolution to optimal FFT size if desired
+            if (bAdjustResolution)
+              deskewedXdim = findOptimalDimension(deskewedXdim);
+
+            // update z step size:
+            imgParams.dz *= fabs(sin(deskewAngle * M_PI/180.));
+            if (fabs(deskewFactor) < 1) {
+#ifdef _WIN32
+              SetConsoleTextAttribute(hConsole, 14); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+              printf("Warning : deskewFactor is < 1.  Check that angle, dz, and dr sizes are correct.\n");
+#ifdef _WIN32
+              SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+            }
+            printf("old dz = %f, dxy = %f, deskewFactor = %f, new nx = %d, new dz = %f\n", old_dz, imgParams.dr, deskewFactor, deskewedXdim, imgParams.dz);
+
+          }
+
+
+
+          //****************************Construct rotation matrix***********************************
+          if (fabs(rotationAngle) > 0.0) {
+            rotMatrix.resize(4*sizeof(float));
+            rotationAngle *= M_PI/180;
+            float stretch = imgParams.dr / imgParams.dz;
+            float *p = (float *)rotMatrix.getPtr();
+            p[0] = cos(rotationAngle) * stretch;
+            p[1] = sin(rotationAngle) * stretch;
+            p[2] = -sin(rotationAngle);
+            p[3] = cos(rotationAngle);
+          }
+
+
+
+          if (wiener >0) {
+            //****************************Wiener filter instead of RL (not usually used.):***********************************
+            raw_imageFFT.assign(deskewedXdim+2, new_ny, new_nz);
+
+            if (!fftwf_init_threads()) { /* one-time initialization required to use threads */
+              printf("Error returned by fftwf_init_threads()\n");
+            }
+
+            fftwf_plan_with_nthreads(8);
+            rfftplan = fftwf_plan_dft_r2c_3d(new_nz, new_ny, deskewedXdim,
+                                             raw_image.data(),
+                                             (fftwf_complex *) raw_imageFFT.data(),
+                                             FFTW_ESTIMATE);
+            rfftplan_inv = fftwf_plan_dft_c2r_3d(new_nz, new_ny, deskewedXdim,
+                                                 (fftwf_complex *) raw_imageFFT.data(),
+                                                 raw_image.data(),
+                                                 FFTW_ESTIMATE);
+          }
+          else if (RL_iters>0) {
+
+            //****************************RL decon***********************************
+
+            //****************************Create reusable cuFFT plans***********************************
+            //
+            size_t workSize = 0;
+            cufftResult cuFFTErr;
+
+            if (cufftGetSize(rfftplanGPU, &workSize) == CUFFT_SUCCESS) { // if plan existed before, destroy it before creating a new plan.
+              cufftDestroy(rfftplanGPU);
+              std::cout << "Destroying rfftplanGPU." << std::endl;
+            }
+            if (cufftGetSize(rfftplanInvGPU, &workSize) == CUFFT_SUCCESS) { // if plan existed before, destroy it before creating a new plan.
+              cufftDestroy(rfftplanInvGPU);
+              std::cout << "Destroying rfftplanInvGPU." << std::endl;
+            }
+
+            size_t GPUfree_prev;
+            cudaMemGetInfo(&GPUfree_prev, &GPUtotal);
+
+            unsigned nz_final;
+            if (bDupRevStack)  // to reduce severe Z ringing
+              nz_final = new_nz*2;
+            else
+              nz_final = new_nz;
+
+            if (0) {
+              // old way,  just autoallocate FFTplans.
+              // This will always be on the GPU, and the two plans
+              // (even though are serially exectuted) cannot share workspace.
+              cuFFTErr = cufftPlan3d(&rfftplanGPU, nz_final, new_ny, deskewedXdim, CUFFT_R2C);
+              if (cuFFTErr != CUFFT_SUCCESS) {
+                // std::cerr << "cufftPlan3d() r2c failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+                cudaMemGetInfo(&GPUfree, &GPUtotal);
+                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
+
+                cufftEstimate3d(nz_final, new_ny, deskewedXdim, CUFFT_R2C, &workSize);
+                std::cerr << "R2C FFT Plan desires " << workSize / (1024 * 1024) << " MB. " << std::endl;
+                throw std::runtime_error("cufftPlan3d() r2c failed.");
+              }
+
+
+              cuFFTErr = cufftPlan3d(&rfftplanInvGPU, nz_final, new_ny, deskewedXdim, CUFFT_C2R);
+              if (cuFFTErr != CUFFT_SUCCESS) {
+                // std::cerr << "cufftPlan3d() c2r failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+                cudaMemGetInfo(&GPUfree, &GPUtotal);
+                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
+
+                cufftEstimate3d(nz_final, new_ny, deskewedXdim, CUFFT_R2C, &workSize);
+                std::cerr << "C2R FFT Plan desires " << workSize / (1024 * 1024) << " MB. " << std::endl;
+                throw std::runtime_error("cufftPlan3d() c2r failed.");
+              }
+            }
+            else {
+              // new way, share FFTplan workarea.
+              // Possibly put this area on the Host RAM if it doesn't fit in GPU RAM.
+              int autoAllocate   = 0; // don't allocate, we want to specify the workspace ourselves.
+              size_t workSizeR2C = 0; // size of R2C plan to be filled in by cuFFT
+              size_t workSizeC2R = 0; // size of C2R plan to be filled in by cuFFT
+              workSize    = 0; // necessary size of plan to enable R2C or C2R (i.e. max of these)
+
+              cuFFTErr = cufftCreate(&rfftplanGPU);                           // create object.
+              cuFFTErr = cufftSetAutoAllocation(rfftplanGPU, autoAllocate);
+              if (bSkewedDecon)
+                cuFFTErr = cufftMakePlan3d(rfftplanGPU, nz_final, new_ny, new_nx, CUFFT_R2C, &workSizeR2C);   // make plan, retrieve needed workSize
+              else
+                cuFFTErr = cufftMakePlan3d(rfftplanGPU, nz_final/*new_nz??*/, new_ny, deskewedXdim, CUFFT_R2C, &workSizeR2C);   // make plan, retrieve needed workSize
+              if (cuFFTErr != CUFFT_SUCCESS) {
+                std::cerr << "cufftMakePlan3d() r2c failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+                cudaMemGetInfo(&GPUfree, &GPUtotal);
+                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
+
+                cuFFTErr = cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_R2C, &workSizeR2C);
+                if (cuFFTErr != CUFFT_SUCCESS)
+                  std::cerr << "cufftEstimate3d() failed. " << new_nz << " x " << new_ny << " x " << deskewedXdim << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+
+                std::cerr << "R2C FFT Plan desires " << workSizeR2C / (1024 * 1024) << " MB. " << std::endl;
+                throw std::runtime_error("cufftMakePlan3d() r2c failed.");
+              }
+
+              cuFFTErr = cufftCreate(&rfftplanInvGPU);                        // create object.
+              if (cuFFTErr != CUFFT_SUCCESS)
+                std::cerr << "cufftCreate(&rfftplanInvGPU) failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+
+              cuFFTErr = cufftSetAutoAllocation(rfftplanInvGPU, autoAllocate);
+              if (cuFFTErr != CUFFT_SUCCESS)
+                std::cerr << "cufftSetAutoAllocation(rfftplanInvGPU, autoAllocate) failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+
+              if (bSkewedDecon)
+                cuFFTErr = cufftMakePlan3d(rfftplanInvGPU, nz_final, new_ny, new_nx, CUFFT_C2R, &workSizeC2R);// make plan, get workSize
+              else
+                cuFFTErr = cufftMakePlan3d(rfftplanInvGPU, nz_final/*new_nz??*/, new_ny, deskewedXdim, CUFFT_C2R, &workSizeC2R);// make plan, get workSize
+              if (cuFFTErr != CUFFT_SUCCESS) {
+                std::cerr << "cufftMakePlan3d() c2r failed. " << new_nz << " x " << new_ny << " x " << deskewedXdim << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+                cudaMemGetInfo(&GPUfree, &GPUtotal);
+                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
+
+                cuFFTErr = cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_C2R, &workSizeC2R);
+                if (cuFFTErr != CUFFT_SUCCESS)
+                  std::cerr << "cufftEstimate3d() failed. " << new_nz << " x " << new_ny << " x " << deskewedXdim << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+
+                std::cerr << "C2R FFT Plan desires " << workSizeC2R / (1024 * 1024) << " MB. " << std::endl;
+                throw std::runtime_error("cufftMakePlan3d() c2r failed.");
+              }
+
+              if (workSizeC2R > workSizeR2C) {
+                workSize = workSizeC2R;    // set workSize to max of C2R and R2C plans.
+              }
+              else {
+                workSize = workSizeR2C;
+              }
+
+              if (workArea.getSize() != workSize) {  // do we need to (re)allocate workArea?
+                workArea.resize(workSize);
+                std::cout << "FFTplan workarea allctd.   (";
+                cudaMemGetInfo(&GPUfree, &GPUtotal);
+                std::cout << std::setw(4) << workArea.getSize() / (1024 * 1024) << "MB)" << std::setw(7) << GPUfree / (1024 * 1024) << "MB free " << std::endl;
+              }
+
+              cuFFTErr = cufftSetWorkArea(rfftplanGPU, workArea.getPtr());
+              if (cuFFTErr != CUFFT_SUCCESS) {
+                std::cerr << "cufftSetWorkArea() r2c failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+                cudaMemGetInfo(&GPUfree, &GPUtotal);
+                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
+
+                cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_R2C, &workSizeR2C);
+                std::cerr << "R2C FFT Plan desires " << workSizeR2C / (1024 * 1024) << " MB. " << std::endl;
+                throw std::runtime_error("cufftSetWorkArea() r2c failed.");
+              }
+
+              cuFFTErr = cufftSetWorkArea(rfftplanInvGPU, workArea.getPtr());
+              if (cuFFTErr != CUFFT_SUCCESS) {
+                std::cerr << "cufftSetWorkArea() c2r failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+                cudaMemGetInfo(&GPUfree, &GPUtotal);
+                std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
+
+                cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_C2R, &workSizeC2R);
+                std::cerr << "C2R FFT Plan desires " << workSizeC2R / (1024 * 1024) << " MB. " << std::endl;
+                throw std::runtime_error("cufftSetWorkArea() c2r failed.");
+              }
+
+            } // end FFT plan allocation method (either normal way or "shared" plan way)
+
+            std::cout << "FFT plans allocated.    ";
+            cudaMemGetInfo(&GPUfree, &GPUtotal);
+            std::cout << std::setw(8) << (GPUfree_prev - GPUfree) / (1024 * 1024) << "MB" << std::setw(8) << GPUfree / (1024 * 1024)
+                      << "MB free" << " nz=" << new_nz << ", ny=" << new_ny << ", nx=" << deskewedXdim << std::endl;
+
+          }  //else if (RL_iters>0)
+
+          //****************Transfer a bunch of constants to device, including OTF array:*******************
+
+          if (bSkewedDecon)
+            dkx = 1.0/(imgParams.dr * new_nx);
+          else
+            dkx = 1.0/(imgParams.dr * deskewedXdim);
+          dky = 1.0/(imgParams.dr * new_ny);
+
+          unsigned nz_const;   // why not keep using "nz_final"??
+          if (bDupRevStack)
+            nz_const = new_nz*2;
+          else
+            nz_const = new_nz;
+          dkz = 1.0/(imgParams.dz * nz_const);
+
+          rdistcutoff = 2*NA/(imgParams.wave); // lateral resolution limit in 1/um
+          float eps = std::numeric_limits<float>::epsilon();
+
+          if (bSkewedDecon) {
+            transferConstants(nx, new_ny, nz_const,
+                              nx_otf, ny_otf, nz_otf,
+                              dkx/dkx_otf, dky/dky_otf, dkz/dkz_otf,
+                              eps);
+            d_interpOTF.resize(nz_const * new_ny * (new_nx+2) * sizeof(float)); // allocate memory
+            makeOTFarray(d_rawOTF, d_interpOTF, new_nx, new_ny, nz_const); // interpolate
+          }
+          else {
+            transferConstants(deskewedXdim, new_ny, nz_const,
+                              nx_otf, ny_otf, nz_otf,
+                              dkx/dkx_otf, dky/dky_otf, dkz/dkz_otf,
+                              eps);
+
+            d_interpOTF.resize(nz_const * new_ny * (deskewedXdim+2) * sizeof(float)); // allocate memory
+            makeOTFarray(d_rawOTF, d_interpOTF, deskewedXdim, new_ny, nz_const); // interpolate.  This reads from the complexOTF.data sent to the GPU from transferConstants().
+          }
+          d_rawOTF.resize(0);
+          std::cout << "d_interpOTF allocated.  ";
+          cudaMemGetInfo(&GPUfree, &GPUtotal);
+          std::cout << std::setw(8) << d_interpOTF.getSize() / (1024 * 1024) << "MB" << std::setw(8) << GPUfree / (1024 * 1024) << "MB free" << std::endl;
+
+          //****************************Prepare Light Sheet Correction if desired ***********************
+
+          if (LSfile.size()) {
+
+            const float my_min = 0.2;
+
+            std::cout << std::endl << "Loading LS Correction      : ";
+            LSImage.assign(LSfile.c_str());
+            std::cout << LSImage.width() << " x " << LSImage.height() << " x " << LSImage.depth() << ". " << std::endl;
+            AverageLS.resize(LSImage.width(), LSImage.height(), 1, 1, -1); //Set size of AverageLS
+            AverageLS.fill(0); //fill with zeros
+
+            cimg_forXYZ(LSImage, x, y, z) {
+              AverageLS(x, y) = AverageLS(x, y) + LSImage(x, y, z); //sum image
+
+              if (z == (LSImage.depth() - 1)) // if this is the last Z slice
+                AverageLS(x, y) = AverageLS(x, y) / LSImage.depth(); //divide by number of slices
+            }
+
+            const int LSIx = AverageLS.width();
+            const int LSIy = AverageLS.height();
+
+            int LSIborderx = (LSIx - nx) / 2;
+            int LSIbordery = (LSIy - ny) / 2;
+
+            std::cout << "Excess LS border to crop   : " << LSIborderx << " x " << LSIbordery << std::endl;
+
+            AverageLS.crop(LSIborderx, LSIbordery, LSIx - LSIborderx - 1, LSIy - LSIbordery - 1); //crop it
+
+            cimg_forXY(AverageLS, x, y)
+              AverageLS(x, y) = AverageLS(x, y) - background;
+
+
+            img_max = AverageLS(0, 0);
+            img_min = AverageLS(0, 0);
+            cimg_forXY(AverageLS, x, y) {
+              img_max = std::max(AverageLS(x, y), img_max);
+              img_min = std::min(AverageLS(x, y), img_min);
+            }
+            std::cout << "               LS max, min : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
+
+            const float normalization = img_max;
+
+            img_max = -9999999;
+            img_min = 9999999;
+            cimg_forXY(AverageLS, x, y) {
+              AverageLS(x, y) = AverageLS(x, y) / normalization;
+              img_max = std::max(AverageLS(x, y), img_max);
+              img_min = std::min(AverageLS(x, y), img_min);
+            }
+            std::cout << "       After normalization : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
+
+
+            AverageLS.max(my_min); // set everything below 0.2 to 0.2.  This will prevent divide by zero.
+          } // end if (LSfile.size())
+
+        } // end if (nx == 0 || bDifferent_sized_raw_img )
+
+        //****************************Apply Light Sheet Correction if desired ***********************
+        if (LSfile.size()) {
+          CImg<float> Temp(raw_image); // Copy raw_image to a floating point image
+
+          cimg_forXYZ(Temp, x, y, z)
+            Temp(x, y, z) = Temp(x, y, z) - background; // subtract background. min value =0.
+
+          Temp.max((float)0); // set min value to 0.  have to cast zero to avoid compiler complaint.
+
+          if (it == all_matching_files.begin()) {
+            img_max = AverageLS(0, 0);
+            img_min = AverageLS(0, 0);
+
+            cimg_forXY(AverageLS, x, y) {
+              img_max = std::max(AverageLS(x, y), img_max);
+              img_min = std::min(AverageLS(x, y), img_min);
+            }
+            std::cout << "LSC size                   : " << AverageLS.width() << " x " << AverageLS.height() << " x " << AverageLS.depth() << std::endl;
+            std::cout << "LSC max, min               : " << img_max << ", " << img_min << std::endl;
+          }
+
+          std::cout << "Dividing by LSC... ";
+
+          Temp.div(AverageLS);
+          std::cout << " Done." << std::endl;
+
+          cimg_forXYZ(Temp, x, y, z)
+            raw_image(x, y, z) = Temp(x, y, z) + background; //replace background and copy back to U16 raw_image.
+        } // end if applying LS correction
+
+        voxel_size[0] = imgParams.dr;
+        voxel_size[1] = imgParams.dr;
+        voxel_size[2] = imgParams.dz;
+        imdz = imgParams.dz;
+        if (rotMatrix.getSize()) {
+          imdz = imgParams.dr;
+        }
+        voxel_size_decon[0] = imgParams.dr;
+        voxel_size_decon[1] = imgParams.dr;
+        voxel_size_decon[2] = imdz;
+        std::string s = "ImageJ=1.50i\n"
+          "spacing=" + std::to_string(imgParams.dz) + "\n"
+          "unit=micron";
+        description = s.c_str();
+
+        //****************************Pad image.  Use Mirror image in padded border region***********************************
+
+        if (Pad) {
+          border_x = (new_nx - nx) / 2;   // get border size
+          border_y = (new_ny - ny) / 2;
+          border_z = (new_nz - nz) / 2;
+
+          std::cout << std::endl <<  "Create padded img.  Border : " << border_x << " x " << border_y << " x " << border_z << ". " << std::endl;
+          CImg<> raw_original(raw_image);       //copy from raw image
+          std::cout << "Image with padding size    : " << new_nx << " x " << new_ny << " x " << new_nz << ". ";
+          raw_image.resize(new_nx, new_ny, new_nz);     //resize with border
+
+          int x_raw;
+          int y_raw;
+          int z_raw;
+
+          int i_nx = (int)nx;
+          int i_ny = (int)ny;
+          int i_nz = (int)nz;
+
+          // std::cout << "Line:" << __LINE__ << std::endl;
+          std::cout << "Copy values... ";
+          cimg_forXYZ(raw_image, x, y, z) // for every pixel in the new image, copy value from original image
+            {
+              x_raw = abs(x - border_x);
+              y_raw = abs(y - border_y);
+              z_raw = abs(z - border_z);
+
+              if (x_raw >= i_nx)
+                x_raw = i_nx - (x_raw - i_nx) - 1;
+
+              if (y_raw >= i_ny)
+                y_raw = i_ny - (y_raw - i_ny) - 1;
+
+              if (z_raw >= i_nz)
+                z_raw = i_nz - (z_raw - i_nz) - 1;
+
+              //raw_image(x, y, z) = x_raw;
+              raw_image(x, y, z) = raw_original(x_raw, y_raw, z_raw);
+            }
+          //***debug padded image.
+          if (false) {
+            std::cout << "Saving padded image... " << std::endl;
+            makeNewDir("Padded");
+            CImg<unsigned short> uint16Img(raw_image);
+            uint16Img.save_tiff(makeOutputFilePath(*it, "Padded", "_padded").c_str(), 0, voxel_size, description);
+          }
+          std::cout << "Done." << std::endl;
+        } // End Pad image creation.
+
+        // moved here from boostfs.cpp in order to make it conditional on actually performing decon
+        // this MAY cause some bugs ... but haven't seen any since adding a long time ago
+        if (RL_iters || rotMatrix.getSize()) {
+          if (it == all_matching_files.begin()) //make directory only on first call, and if we are saving Deskewed.
+            makeNewDir("GPUdecon");
+        }
+
+        // initialize the raw_deskewed size everytime in case it is cropped on an earlier iteration
+        if (bSaveDeskewedRaw && (fabs(deskewAngle) > 0.0) ) {
+          raw_deskewed.assign(deskewedXdim, new_ny, new_nz);
+
+          if (it == all_matching_files.begin() + skip) //make directory only on first call, and if we are saving Deskewed.
+            makeNewDir("Deskewed");
+        }
+
+        // If deskew is to happen, it'll be performed inside RichardsonLucy_GPU() on GPU;
+        // but here raw data's x dimension is still just "new_nx"
+        if (bCrop)
+          raw_image.crop(0, 0, 0, 0, new_nx-1, new_ny-1, new_nz-1, 0);
+
+        if (wiener >0) { // plain 1-step Wiener filtering
+          raw_image -= background;
+          fftwf_execute_dft_r2c(rfftplan, raw_image.data(), (fftwf_complex *) raw_imageFFT.data());
+
+          wienerfilter(raw_imageFFT,
+                       dkx, dky, dkz,
+                       complexOTF,
+                       dkx_otf, dkz_otf, // keep wiener filter stuff??
+                       rdistcutoff, wiener);
+
+          fftwf_execute_dft_c2r(rfftplan_inv, (fftwf_complex *) raw_imageFFT.data(), raw_image.data());
+          raw_image /= raw_image.size();
+        }
+        else if (RL_iters || raw_deskewed.size() || rotMatrix.getSize()) {
+#ifndef NDEBUG
+          img_max = raw_image(0, 0, 0);
+          img_min = raw_image(0, 0, 0);
+          cimg_forXYZ(raw_image, x, y, z) {
+            img_max = std::max(raw_image(x, y, z), img_max);
+            img_min = std::min(raw_image(x, y, z), img_min);
+          }
+          std::cout << "RL_image : " << raw_image.width() << " x " << raw_image.height() << " x " << raw_image.depth() << ". " << std::endl;
+          std::cout << "         RL_image max, min : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
+#endif
+          float my_median = 1;
+          if (bFlatStartGuess)
+            my_median = raw_image.median();
+
+#ifdef USE_NVTX
+          cudaProfilerStart();
+#endif
+
+          //************************************************************************************
+          //****************************Run RL GPU**********************************************
+          //************************************************************************************
+          RichardsonLucy_GPU(raw_image, background, d_interpOTF, RL_iters, deskewFactor,
+                             deskewedXdim, extraShift, napodize, nZblend, rotMatrix,
+                             rfftplanGPU, rfftplanInvGPU, raw_deskewed, &deviceProp,
+                             bFlatStartGuess, my_median, bDoRescale, bSkewedDecon,
+                             padVal, bDupRevStack,
+                             UseOnlyHostMem, myGPUdevice);
+#ifdef USE_NVTX
+          cudaProfilerStop();
+#endif
+        }
+        else {
+          std::cerr << "Nothing is performed\n";
+        }
+
+#ifndef NDEBUG
+        img_max = raw_image(0, 0, 0);
+        img_min = raw_image(0, 0, 0);
+        cimg_forXYZ(raw_image, x, y, z) {
+          img_max = std::max(raw_image(x, y, z), img_max);
+          img_min = std::min(raw_image(x, y, z), img_min);
+        }
+        std::cout << "output_image : " << raw_image.width() << " x " << raw_image.height() << " x " << raw_image.depth() << ". " << std::endl;
+        std::cout << "         output_image max, min : " << std::setw(8) << img_max << ", " << std::setw(8) << img_min << std::endl;
+#endif
+
+        //****************************Stitch tiles***********************************
+
+        if (number_of_tiles > 1) { // are we tiling?
+
+          if (tile_index == 0) {
+            stitch_image.assign(raw_image.width(), file_image.height(), raw_image.depth()); // initialize destination stitch_image.
+            std::cout << "         stitch_image : " << stitch_image.width() << " x " << stitch_image.height() << " x " << stitch_image.depth() << ". " << std::endl;
+            stitch_image.fill((float)0.0);
+
+            blend_weight_image.assign(raw_image.width(), file_image.height(), raw_image.depth()); // initialize destination blend_weight_image.
+            blend_weight_image.fill(0);
+          }
+          // int no_zone    = floor((float)tile_overlap / 3) ;  // 1/3 no_zone, 1/3 blend zone, 1/3 no_zone
+          int no_zone    = ceil((tile_overlap - 4) / 2.0) ;  //  no_zone, 4 pixel blend zone, yes_zone
+          int blend_zone = tile_overlap - no_zone - no_zone;
+
+          std::cout << "           tile_image : " << raw_image.width() << " x " << raw_image.height() << " x " << raw_image.depth() << ". tile_overlap: " << tile_overlap << ". blend_zone: " << blend_zone << ". tile_y_offset:" << tile_y_offset << ". " << std::endl;
+          bool is_first_tile = tile_index == 0;
+          bool is_last_tile = tile_index + 1 >= number_of_tiles;
+
+          cimg_forXYZ(raw_image, x, y, z) {
+            float blend = 1;
+
+            if (is_first_tile && y <= tile_overlap)
+              blend = 1;// front overlap region of 1st tile
+            else if (is_last_tile && y >= raw_image.height() - tile_overlap )
+              blend = 1;// back overlap region of last tile
+            else {
+              if (y <= no_zone) // front no_zone?
+                blend = 0;
+
+              else if(y > no_zone && y <= no_zone + blend_zone) // front blend region?
+                blend = (double)(y - no_zone) / blend_zone;
+
+              else if (y >= raw_image.height() - no_zone) // back no zone?
+                blend = 0;
+
+              else blend = 1; // middle zone or back blend zone
+            }
+
+            if (y + tile_y_offset < stitch_image.height()) { /* are we inside of the destination image?*/
+
+              if (BlendTileOverlap) { // blend the overlap?
+                if (blend > 0 && blend < 1 && blend_weight_image(x, y + tile_y_offset, z) > 0) { // need to blend?
+                  stitch_image(x, y + tile_y_offset, z) = (raw_image(x, y, z) * blend) + (stitch_image(x, y + tile_y_offset, z) * (1.0 - blend)); // insert into image with blend in overlap region
+                  //stitch_image(x, y + tile_y_offset, z) = blend * 1000;
+                }
+
+                else if (blend > 0 && blend_weight_image(x, y + tile_y_offset, z) == 0) // just put this pixel into the image
+                  stitch_image(x, y + tile_y_offset, z) = raw_image(x, y, z);
+
+                else if (blend == 1)
+                  stitch_image(x, y + tile_y_offset, z) = raw_image(x, y, z); // just put this pixel into the image
+
+                if (blend > 0)
+                  blend_weight_image(x, y + tile_y_offset, z) = 1;
+              }
+              else // overlap is either 1 tile or the other.
+                {
+                  bool is_past_front_overlap = (y >= floor((float)tile_overlap / 2.0) || is_first_tile);
+                  bool is_before_end_overlap = (y < floor(raw_image.height() - (float)tile_overlap / 2.0) || is_last_tile);
+
+                  if (is_past_front_overlap && is_before_end_overlap)
+                    stitch_image(x, y + tile_y_offset, z) = raw_image(x, y, z); // insert into image directly without blend in overlap region
+                }
+            }
+
+          } // end loop on pixels
+        } // end if (number_of_tiles > 1)
+        else
+          stitch_image.assign(raw_image, false); // no tiling, so just do image copy.
+
+      } // end for (int tile_index = 0; ... ) tiling loop
+
+      //****************************Crop***********************************
+
+      //remove padding
+      if (Pad)
+        stitch_image.crop(
+                          border_x, border_y,             // X, Y
+                          border_z, 0,                    // Z, C
+                          border_x + nx, border_y + ny,   // X, Y
+                          border_z + nz, 0);              // Z, C
+
+      if (! final_CropTo_boundaries.empty()) {
+        stitch_image.crop(final_CropTo_boundaries[0], final_CropTo_boundaries[2],   // X, Y
+                          final_CropTo_boundaries[4], 0,                            // Z, C
+                          final_CropTo_boundaries[1], final_CropTo_boundaries[3],   // X, Y
+                          final_CropTo_boundaries[5], 0);                           // Z, C
+        if (raw_deskewed.size()) {
+          // std::cout << std::endl << "The 'raw_deskewed' buffer uses " << raw_deskewed.size()*sizeof(float) << " bytes." << std::endl;
+          raw_deskewed.crop(final_CropTo_boundaries[0], final_CropTo_boundaries[2],
+                            final_CropTo_boundaries[4], 0,
+                            final_CropTo_boundaries[1], final_CropTo_boundaries[3],
+                            final_CropTo_boundaries[5], 0);
+        }
+      }
+
+      if (tsave.joinable()) {
+        tsave.join();           // wait for previous saving thread to finish.
+        tsave.~thread();        // destroy thread.
+      }
+
+      if (tDeskewsave.joinable()) {
+        tDeskewsave.join();     // wait for previous saving thread to finish.
+        tDeskewsave.~thread();  // destroy thread.
+      }
+
+
+      //****************************Save Deskewed Raw***********************************
+      if (bSaveDeskewedRaw && (fabs(deskewAngle) > 0.0)) {
+        if (!bSaveUshort) {
+          DeskewedToSave.assign(raw_deskewed);
+          tDeskewsave = std::thread(DeSkewsave_in_thread, *it, voxel_size, description); //start saving "Deskewed To Save" file.
+          //raw_deskewed.save_tiff(makeOutputFilePath(*it, "Deskewed", "_deskewed").c_str(), 0, voxel_size, description);
+        }
+        else {
+          CImg<unsigned short> uint16Img(raw_deskewed);
+          uint16Img.save_tiff(makeOutputFilePath(*it, "Deskewed", "_deskewed").c_str(), compression, voxel_size, description);
+        }
+      }
+
+
+      //****************************Save Deskewed MIPs***********************************
+      if (bDoRawMaxIntProj.size() == 3 && bSaveDeskewedRaw) {
+        if(it == all_matching_files.begin() && (bDoRawMaxIntProj[0] || bDoRawMaxIntProj[1] || bDoRawMaxIntProj[2]))
+          makeNewDir("Deskewed/MIPs");
+
+        if (bDoRawMaxIntProj[0]) {
+          CImg<> proj = MaxIntProj(raw_deskewed, 0);
+          proj.save_tiff(makeOutputFilePath(*it, "Deskewed/MIPs", "_MIP_x").c_str(), compression, voxel_size, description);
+        }
+        if (bDoRawMaxIntProj[1]) {
+          CImg<> proj = MaxIntProj(raw_deskewed, 1);
+          proj.save_tiff(makeOutputFilePath(*it, "Deskewed/MIPs", "_MIP_y").c_str(), compression, voxel_size, description);
+        }
+        if (bDoRawMaxIntProj[2]) {
+          CImg<> proj = MaxIntProj(raw_deskewed, 2);
+          proj.save_tiff(makeOutputFilePath(*it, "Deskewed/MIPs", "_MIP_z").c_str(), compression, voxel_size, description);
+        }
+
+      }
+
+      //****************************Save MIPs***********************************
+
+      // I had to modify this a bit to save the behavior of --saveDeskewedRaw when NO RL is being performed...
+      // otherwise, it was trying to create folders it shouldn't...
+      // this might have unintended side effects (notably with weiner filtering only... and maybe others)
+      if (bDoMaxIntProj.size() == 3 && RL_iters && (bDoMaxIntProj[0] || bDoMaxIntProj[1] || bDoMaxIntProj[2])) {
+        if (it == all_matching_files.begin() + skip) {
+          makeNewDir("GPUdecon/MIPs");
+        }
+
+        if (bDoMaxIntProj[0]) {
+          CImg<> proj = MaxIntProj(stitch_image, 0);
+          if (bSaveUshort) {
+            CImg<unsigned short> uint16Img(proj);
+            uint16Img.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_x").c_str(), compression, voxel_size, description);
+          }
+          else
+            {
+              proj.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_x").c_str(), compression, voxel_size, description);
+            }
+        }
+        if (bDoMaxIntProj[1]) {
+          CImg<> proj = MaxIntProj(stitch_image, 1);
+          if (bSaveUshort) {
+            CImg<unsigned short> uint16Img(proj);
+            uint16Img.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_y").c_str(), compression, voxel_size, description);
+          }
+          else
+            {
+              proj.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_y").c_str(), compression, voxel_size, description);
+            }
+        }
+        if (bDoMaxIntProj[2]) {
+          CImg<> proj = MaxIntProj(stitch_image, 2);
+          if (bSaveUshort) {
+            CImg<unsigned short> uint16Img(proj);
+            uint16Img.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_z").c_str(), compression, voxel_size, description);
+          }
+          else
+            {
+              proj.save_tiff(makeOutputFilePath(*it, "GPUdecon/MIPs", "_MIP_z").c_str(), compression, voxel_size, description);
+            }
+        }
+      }
+
+      //****************************Save Decon Image***********************************
+      if (RL_iters || rotMatrix.getSize()) {
+        // Stupid to redefine these here... but couldn't get the Z voxel size to work
+        // correctly in ImageJ otherwise...
+
+        if (!bSaveUshort) {
+
+          ToSave.assign(stitch_image); //copy decon image (i.e. stitch_image) to new image space for saving.
+          // ToSave.save_tiff(makeOutputFilePath(*it).c_str(), compression, voxel_size, description);
+
+          tsave = std::thread(save_in_thread, *it, voxel_size_decon, imdz); //start saving "To Save" file.
+        }
+        else {
+          U16ToSave = stitch_image;
+          tsave = std::thread(U16save_in_thread, *it, voxel_size_decon, imdz); //start saving "To Save" file.
+        }
+      }
+
+      /// please leave this here for LLSpy
+      printf(">>>file_finished\n");
+
+      iter_duration = (std::clock() - start_t) / (double)CLOCKS_PER_SEC / (it - (all_matching_files.begin() + skip) + 1 );
+    } // end for (std::vector<std::string>::iterator it= all_matching_files.begin() + skip;
+
+    if (tsave.joinable()) {
+      tsave.join();               // wait for previous saving thread to finish.
+      tsave.~thread();            // destroy thread.
+    } //Make sure we have finished saving.
+
+    if (tDeskewsave.joinable()) {
+      tDeskewsave.join();         // wait for previous saving thread to finish.
+      tDeskewsave.~thread();      // destroy thread.
+    } //Make sure we have finished saving.
+
+    duration = (std::clock() - start_t) / (double)CLOCKS_PER_SEC;
+
+#ifdef _WIN32
+    SetConsoleTextAttribute(hConsole, 10); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+    std::cout << "*** Finished! Elapsed " << duration << " seconds.  ";
+    if (skip != 0)
+      std::cout << "Skipped " << skip << "images.  ";
+    std::cout << "Processed " << all_matching_files.size() - skip << " images.  " << duration / all_matching_files.size() << " seconds per image. ***" << std::endl;
+#ifdef _WIN32
+    SetConsoleTextAttribute(hConsole, 7); // colors are 9=blue 10=green and so on to 15=bright white 7=normal http://stackoverflow.com/questions/4053837/colorizing-text-in-the-console-with-c
+#endif
+
+  } // end try {} block
+  catch (std::exception &e) {
+    std::cerr << "\n!!Error occurred: " << e.what() << std::endl;
+    return 0;
+  }
+  return 0;
 }
 
 

--- a/src/linearDecon.h
+++ b/src/linearDecon.h
@@ -32,6 +32,7 @@
 #include <math.h>
 
 #define cimg_use_tiff
+#define cimg_display 0
 #include <CImg.h>
 using namespace cimg_library;
 
@@ -150,17 +151,20 @@ void RichardsonLucy_GPU(CImg<> &raw, float background, GPUBuffer &otf,
                         cufftHandle rfftplanInvGPU,
                         CImg<> &raw_deskewed, cudaDeviceProp *devprop,
                         bool bFlatStartGuess, float my_median, bool bDoRescale,
+                        bool bSkewedDecon,
                         float padVal = 0, bool bDupRevStack = false,
                         bool UseOnlyHostMem = false, int myGPUdevice = 0);
 
 CImg<> MaxIntProj(CImg<> &input, int axis);
 
-void transferConstants(int nx, int ny, int nz, int nrotf, int nzotf,
-                       float kxscale, float kyscale, float kzscale, float eps,
-                       float *otf);
+void transferConstants(int nx, int ny, int nz, int nxotf, int nyotf, int nzotf,
+                       float kxscale, float kyscale, float kzscale, float eps);
 unsigned findOptimalDimension(unsigned inSize, int step = -1);
 // void prepareOTFtexture(float * realpart, float * imagpart, int nx, int ny);
-void makeOTFarray(GPUBuffer &otfarray, int nx, int ny, int nz);
+void determine_OTF_dimensions(CImg<> &complexOTF, float dr_psf, float dz_psf,
+                              unsigned &nx_otf, unsigned &ny_otf, unsigned &nz_otf,
+                              float &dkx_otf, float &dky_otf, float &dkz_otf);
+void makeOTFarray(GPUBuffer &raw_otfarray, GPUBuffer &otfarray, int nx, int ny, int nz);
 
 void backgroundSubtraction_GPU(GPUBuffer &img, int nx, int ny, int nz,
                                float background, unsigned maxGridXdim);
@@ -258,7 +262,8 @@ void makeNewDir(std::string subdirname);
   CUDADECON_API int RL_interface_init(int nx, int ny, int nz, float dr,
                                       float dz, float dr_psf, float dz_psf,
                                       float deskewAngle, float rotationAngle,
-                                      int outputWidth, char *OTF_file_name);
+                                      int outputWidth, bool bSkewedDecon,
+                                      char *OTF_file_name);
 
   //! RL_interface() to run deconvolution
   /*!
@@ -276,7 +281,7 @@ void makeNewDir(std::string subdirname);
       const unsigned short *const raw_data, int nx, int ny, int nz,
       float *result, float *raw_deskewed_result, float background,
       bool bDoRescale, bool bSaveDeskewedRaw, int nIters, int extraShift,
-      int napodize = 0, int nZblend = 0, float padVal = 0,
+      bool bSkewedDecon, int napodize = 0, int nZblend = 0, float padVal = 0,
       bool bDupRevStack = false);
 
   CUDADECON_API int Deskew_interface(


### PR DESCRIPTION
"radialft" now uses flag "-3" to indicate 3D OTF is to be generated
Also, added support for decon-then-deskew mode as discussed with Wes

To-Do: make radialft take multiple PSFs of multiple beads to average 3D OTF