### PR TITLE
Second attemp at merging the following features into the master branch:

### DIFF
--- a/src/OTF_TIFF_viewer.cpp
+++ b/src/OTF_TIFF_viewer.cpp
@@ -20,6 +20,5 @@ int main(int argc, char *argv[])
   for (unsigned i=0; i< btiff.size(); i++)
     btiff(i) = sqrt(abs(std::complex<float> (atiff(2*i), atiff(2*i+1))));
 
-  // btiff = btiff.max() - btiff;
-  btiff.display();
+  btiff.display(0, false);
 }

--- a/src/RL_interface_driver.cpp
+++ b/src/RL_interface_driver.cpp
@@ -12,7 +12,7 @@ int main(int argc, char *argv[])
   // Step 1: call RL_interface_init() once for all images to be 
   // acquired at this session; see linearDecon.h for detailed parameter descriptions
   RL_interface_init(raw.width(), raw.height(), raw.depth(),
-                    .104, .4, .104, .1, -32.8, -32.8, 0, argv[2], 0);
+                    .104, .4, .104, .1, -32.8, -32.8, 0, 0, 0, argv[2]);
 
   // Step 2: allocate buffer for result image, whose dimension might be different than 
   // the raw because CUFFT prefers dimensions to be factorizable to 2, 3, 5, and 7
@@ -21,7 +21,7 @@ int main(int argc, char *argv[])
 
   // Step 3: call the gut of RL deconvolution; see linearDecon.h for detailed parameter descriptions
   // raw.data() and result.data() are just the plain pointers to the memory underneath "raw" and "results" CImg objects
-  RL_interface(raw.data(), raw.width(), raw.height(), raw.depth(), result.data(), 90., 10, 0, 0, 0);
+  RL_interface(raw.data(), raw.width(), raw.height(), raw.depth(), result.data(), 90., 10, 0, 0, 0, 0);
 
   // Saving result into a file for debug; not essential.
   result.save("debug.tif");

--- a/src/RLgpuImpl.cu
+++ b/src/RLgpuImpl.cu
@@ -22,15 +22,16 @@ __constant__ unsigned const_nx;
 __constant__ unsigned const_ny;
 __constant__ unsigned const_nz;
 __constant__ unsigned const_nxyz;
-__constant__ unsigned const_nrotf;
+__constant__ unsigned const_nxotf;
+__constant__ unsigned const_nyotf;
 __constant__ unsigned const_nzotf;
 
 __constant__ float const_kxscale;
 __constant__ float const_kyscale;
 __constant__ float const_kzscale;
 __constant__ float const_eps;
-__constant__ cuFloatComplex
-    const_otf[7680]; // 60 kB should be enough for an OTF array?? (float2 = 8 bytes, so 7680 = 61,440 bytes) GPU Max is 65,536 bytes
+// __constant__ cuFloatComplex
+//     const_otf[7680]; // 60 kB should be enough for an OTF array?? (float2 = 8 bytes, so 7680 = 61,440 bytes) GPU Max is 65,536 bytes
 
 __global__ void filter_kernel(cuFloatComplex *devImg, cuFloatComplex *devOTF,
                               int size);
@@ -70,22 +71,23 @@ template <class T> struct SharedMemory {
 // texture<float, cudaTextureType2D, cudaReadModeElementType> texRef1, texRef2;
 // cudaArray* d_realpart, *d_imagpart;  // used for OTF texture
 
-__host__ void transferConstants(int nx, int ny, int nz, int nrotf, int nzotf,
+__host__ void transferConstants(int nx, int ny, int nz, int nxotf, int nyotf, int nzotf,
                                 float kxscale, float kyscale, float kzscale,
-                                float eps, float *h_otf) {
+                                float eps) {
   cutilSafeCall(cudaMemcpyToSymbol(const_nx, &nx, sizeof(int))); // this could fail with "invalid device symbol" if the code is not compiled for this device compute capability. https://devtalk.nvidia.com/default/topic/474415/cuda-programming-and-performance/copy-to-constant-memory-fails/post/3376488/#3376488
   cutilSafeCall(cudaMemcpyToSymbol(const_ny, &ny, sizeof(int)));
   cutilSafeCall(cudaMemcpyToSymbol(const_nz, &nz, sizeof(int)));
   unsigned int nxyz = nx * ny * nz;
   cutilSafeCall(cudaMemcpyToSymbol(const_nxyz, &nxyz, sizeof(unsigned int)));
-  cutilSafeCall(cudaMemcpyToSymbol(const_nrotf, &nrotf, sizeof(int)));
+  cutilSafeCall(cudaMemcpyToSymbol(const_nxotf, &nxotf, sizeof(int)));
+  cutilSafeCall(cudaMemcpyToSymbol(const_nyotf, &nyotf, sizeof(int)));
   cutilSafeCall(cudaMemcpyToSymbol(const_nzotf, &nzotf, sizeof(int)));
   cutilSafeCall(cudaMemcpyToSymbol(const_kxscale, &kxscale, sizeof(float)));
   cutilSafeCall(cudaMemcpyToSymbol(const_kyscale, &kyscale, sizeof(float)));
   cutilSafeCall(cudaMemcpyToSymbol(const_kzscale, &kzscale, sizeof(float)));
   cutilSafeCall(cudaMemcpyToSymbol(const_eps, &eps, sizeof(float)));
-  cutilSafeCall(
-      cudaMemcpyToSymbol(const_otf, h_otf, nrotf * nzotf * 2 * sizeof(float))); // load complex 2D OTF to GPU array. 
+  // cutilSafeCall(
+  //     cudaMemcpyToSymbol(const_otf, h_otf, nrotf * nzotf * 2 * sizeof(float))); // load complex 2D OTF to GPU array. 
 }
 
 // __host__ void prepareOTFtexture(float * realpart, float * imagpart, int nx,
@@ -119,7 +121,7 @@ __host__ void transferConstants(int nx, int ny, int nz, int nrotf, int nzotf,
 //   cudaBindTextureToArray(texRef2, d_imagpart, channelDesc);
 // }
 
-__global__ void bgsubtr_kernel(float *img, int size, float background) {
+__global__ void bgsubtr_kernel(float *img, size_t size, float background) {
   unsigned ind =
       (blockIdx.y * gridDim.x + blockIdx.x) * blockDim.x + threadIdx.x;
 
@@ -135,9 +137,11 @@ __host__ void backgroundSubtraction_GPU(GPUBuffer &img, int nx, int ny, int nz,
   unsigned nThreads = 1024;
   unsigned NXblock = ceil(nx * ny * nz / (float)nThreads);
   unsigned NYblock = 1;
-  if (NXblock > maxGridXdim)
-    NYblock = NXblock = ceil(sqrt(NXblock));
-
+  if (NXblock > maxGridXdim) {
+    NYblock = NXblock / maxGridXdim + 1;
+    NXblock = maxGridXdim;
+    // NYblock = NXblock = ceil(sqrt(NXblock));
+  }
   dim3 grid(NXblock, NYblock);
   dim3 block(nThreads);
 
@@ -150,7 +154,6 @@ __host__ void backgroundSubtraction_GPU(GPUBuffer &img, int nx, int ny, int nz,
 }
 
 __host__ void filterGPU(GPUBuffer &img, int nx, int ny, int nz,
-                        // GPUBuffer &otf,
                         cufftHandle &rfftplan, cufftHandle &rfftplanInv,
                         GPUBuffer &fftBuf, GPUBuffer &otfArray, bool bConj,
                         unsigned maxGridXdim)
@@ -163,8 +166,11 @@ __host__ void filterGPU(GPUBuffer &img, int nx, int ny, int nz,
   unsigned nThreads = 1024;
   unsigned NXblock = ceil(((float)(nx * ny * nz)) / nThreads);
   unsigned NYblock = 1;
-  if (NXblock > maxGridXdim)
-    NXblock = NYblock = ceil(sqrt(NXblock));
+  if (NXblock > maxGridXdim) {
+    NYblock = NXblock / maxGridXdim + 1;
+    NXblock = maxGridXdim;
+    // NYblock = NXblock = ceil(sqrt(NXblock));
+  }
 
   dim3 gridDim(NXblock, NYblock);
   scale_kernel<<<gridDim, nThreads>>>((float *)img.getPtr(),
@@ -178,7 +184,7 @@ __host__ void filterGPU(GPUBuffer &img, int nx, int ny, int nz,
                                       (cuFloatComplex *)fftBuf.getPtr());
 
   if (cuFFTErr != CUFFT_SUCCESS) {
-    std::cout << "Line:" << __LINE__ << std::endl;
+    std::cerr << "Line:" << __LINE__ << " in function: " << __func__ << std::endl;
     throw std::runtime_error("cufft failed.");
   }
   //
@@ -187,7 +193,13 @@ __host__ void filterGPU(GPUBuffer &img, int nx, int ny, int nz,
 
   unsigned arraySize = nz * ny * (nx / 2 + 1);
   NXblock = ceil(arraySize / (float)nThreads);
-  dim3 grid(NXblock);
+  NYblock = 1;
+  if (NXblock > maxGridXdim) {
+    NYblock = NXblock / maxGridXdim + 1;
+    NXblock = maxGridXdim;
+    // NYblock = NXblock = ceil(sqrt(NXblock));
+  }
+  dim3 grid(NXblock, NYblock);
   dim3 block(nThreads);
 
   if (bConj)
@@ -207,23 +219,25 @@ __host__ void filterGPU(GPUBuffer &img, int nx, int ny, int nz,
                           (cufftReal *)img.getPtr());
 
   if (cuFFTErr != CUFFT_SUCCESS) {
-    std::cout << "Line:" << __LINE__;
+    std::cout << "Line:" << __LINE__ << " in function " << __func__ << std::endl;
     throw std::runtime_error("cufft failed.");
   }
 }
 
 // returns otfval at the given kx, ky, kz coordinates, based on the GPU 2D array "const_otf" which was loaded with "transferConstants"
-__device__ cuFloatComplex dev_otfinterpolate( // cuFloatComplex * d_otf,
-    float kx, float ky, float kz) 
+__device__ cuFloatComplex dev_otfinterpolate(cuFloatComplex * d_rawotf,
+                                             float kx, float ky, float kz)
 /* (kx, ky, kz) is Fourier space coords with origin at kx=ky=kz=0 and going
    betwen -nx(or ny,nz)/2 and +nx(or ny,nz)/2 */
 {
-  float krindex = sqrt(kx * kx + ky * ky);
+//  float krindex = sqrt(kx * kx + ky * ky);
   float kzindex = (kz < 0 ? kz + const_nzotf : kz);
 
   cuFloatComplex otfval = make_cuFloatComplex(0.f, 0.f);
 
-  if (krindex < const_nrotf - 1 && kzindex < const_nzotf) {
+  if (const_nyotf == 1) {// rotationally averaged raw OTF
+    float krindex = sqrt(kx*kx + ky*ky);
+  if (krindex < const_nxotf - 1 && kzindex < const_nzotf) {
     // This should be rewritten using Textures for the interpolation. It will be
     // much easier and faster!
     int irindex, izindex, indices[2][2];
@@ -247,14 +261,61 @@ __device__ cuFloatComplex dev_otfinterpolate( // cuFloatComplex * d_otf,
       indices[1][0] = (irindex + 1) * const_nzotf + izindex;
       indices[1][1] = (irindex + 1) * const_nzotf + (izindex + 1);
     }
-    otfval.x = (1 - ar) * (const_otf[indices[0][0]].x * (1 - az) +
-                           const_otf[indices[0][1]].x * az) +
-               ar * (const_otf[indices[1][0]].x * (1 - az) +
-                     const_otf[indices[1][1]].x * az);
-    otfval.y = (1 - ar) * (const_otf[indices[0][0]].y * (1 - az) +
-                           const_otf[indices[0][1]].y * az) +
-               ar * (const_otf[indices[1][0]].y * (1 - az) +
-                     const_otf[indices[1][1]].y * az);
+    otfval.x = (1 - ar) * (d_rawotf[indices[0][0]].x * (1 - az) +
+                           d_rawotf[indices[0][1]].x * az) +
+               ar * (d_rawotf[indices[1][0]].x * (1 - az) +
+                     d_rawotf[indices[1][1]].x * az);
+    otfval.y = (1 - ar) * (d_rawotf[indices[0][0]].y * (1 - az) +
+                           d_rawotf[indices[0][1]].y * az) +
+               ar * (d_rawotf[indices[1][0]].y * (1 - az) +
+                     d_rawotf[indices[1][1]].y * az);
+  }
+  }
+  else {  // non-RA raw OTF
+    float kxindex = kx; // because of half kx dimension; and no need for conj concern; check!
+    float kyindex = (ky < 0? ky + const_nyotf : ky);
+    if (kxindex < const_nxotf-1 && kyindex < const_nyotf && kzindex < const_nzotf) {
+      int ixindex, iyindex, izindex, indices[2][2][2];
+      float ax, ay, az;
+
+      ixindex = floor(kxindex);
+      iyindex = floor(kyindex);
+      izindex = floor(kzindex);
+
+      int iyindex_plus_1 = (iyindex+1) % const_nyotf;
+      int izindex_plus_1 = (izindex+1) % const_nzotf;
+      ax = kxindex - ixindex;
+      ay = kyindex - iyindex;
+      az = kzindex - izindex;
+      int nxyotf = const_nxotf * const_nyotf;
+
+      // Find the 8 vertices surrounding the point (kxindex, kyindex, kzindex)
+      indices[0][0][0] = izindex*nxyotf        + iyindex*const_nxotf        + ixindex;
+      indices[0][0][1] = izindex*nxyotf        + iyindex*const_nxotf        + (ixindex+1);
+      indices[0][1][0] = izindex*nxyotf        + iyindex_plus_1*const_nxotf + ixindex;
+      indices[0][1][1] = izindex*nxyotf        + iyindex_plus_1*const_nxotf + (ixindex+1);
+      indices[1][0][0] = izindex_plus_1*nxyotf + iyindex*const_nxotf        + ixindex;
+      indices[1][0][1] = izindex_plus_1*nxyotf + iyindex*const_nxotf        + (ixindex+1);
+      indices[1][1][0] = izindex_plus_1*nxyotf + iyindex_plus_1*const_nxotf + ixindex;
+      indices[1][1][1] = izindex_plus_1*nxyotf + iyindex_plus_1*const_nxotf + (ixindex+1);
+
+      otfval.x = (1-az)*(d_rawotf[indices[0][0][0]].x*(1-ay)*(1-ax) +
+                         d_rawotf[indices[0][0][1]].x*(1-ay)*ax +
+                         d_rawotf[indices[0][1][0]].x*ay*(1-ax) +
+                         d_rawotf[indices[0][1][1]].x*ay*ax)    +
+        az*(d_rawotf[indices[1][0][0]].x*(1-ay)*(1-ax) +
+            d_rawotf[indices[1][0][1]].x*(1-ay)*ax +
+            d_rawotf[indices[1][1][0]].x*ay*(1-ax) +
+            d_rawotf[indices[1][1][1]].x*ay*ax);
+      otfval.y = (1-az)*(d_rawotf[indices[0][0][0]].y*(1-ay)*(1-ax) +
+                         d_rawotf[indices[0][0][1]].y*(1-ay)*ax +
+                         d_rawotf[indices[0][1][0]].y*ay*(1-ax) +
+                         d_rawotf[indices[0][1][1]].y*ay*ax)    +
+        az*(d_rawotf[indices[1][0][0]].y*(1-ay)*(1-ax) +
+            d_rawotf[indices[1][0][1]].y*(1-ay)*ax +
+            d_rawotf[indices[1][1][0]].y*ay*(1-ax) +
+            d_rawotf[indices[1][1][1]].y*ay*ax);
+    }
   }
 
   // float krindex = sqrt(kx*kx + ky*ky) / const_nrotf;
@@ -288,29 +349,31 @@ __global__ void filterConj_kernel(cuFloatComplex *devImg,
   }
 }
 
-__global__ void makeOTFarray_kernel(cuFloatComplex *result) {
+__global__ void makeOTFarray_kernel(cuFloatComplex *src, cuFloatComplex *result)
+{
   unsigned kx = blockIdx.x * blockDim.x + threadIdx.x;
   // x>>1 is equivalent to x/2 when x is integer
   int ky = blockIdx.y > const_ny >> 1 ? blockIdx.y - const_ny : blockIdx.y;
   int kz = blockIdx.z > const_nz >> 1 ? blockIdx.z - const_nz : blockIdx.z;
 
-  if (kx < const_nx / 2 + 1) {
-    cuFloatComplex otf_val = dev_otfinterpolate(
-        kx * const_kxscale, ky * const_kyscale, kz * const_kzscale);
-    unsigned ind = blockIdx.z * (const_nx / 2 + 1) * const_ny +
-                   blockIdx.y * (const_nx / 2 + 1) + kx;
+  int half_nx = (const_nx>>1) + 1;
+  if (kx < half_nx) {
+    cuFloatComplex otf_val = dev_otfinterpolate(src, kx*const_kxscale, ky*const_kyscale, kz*const_kzscale);
+    unsigned ind = blockIdx.z * half_nx * const_ny  + blockIdx.y * half_nx + kx;
     result[ind].x = otf_val.x;
     result[ind].y = otf_val.y;
   }
 }
 
-__host__ void makeOTFarray(GPUBuffer &otfarray, int nx, int ny, int nz) {
+__host__ void makeOTFarray(GPUBuffer &raw_otfarray, GPUBuffer &otfarray, int nx, int ny, int nz)
+{
   unsigned nThreads = 128;
   dim3 block(nThreads, 1, 1);
   unsigned blockNx = ceil((nx / 2 + 1) / (float)nThreads);
   dim3 grid(blockNx, ny, nz);
 
-  makeOTFarray_kernel<<<grid, block>>>((cuFloatComplex *)otfarray.getPtr());
+  makeOTFarray_kernel<<<grid, block>>>((cuFloatComplex *) raw_otfarray.getPtr(),
+                                       (cuFloatComplex *)otfarray.getPtr());
 #ifndef NDEBUG
   std::cout << "makeOTFarray(): " << cudaGetErrorString(cudaGetLastError())
             << std::endl;
@@ -333,8 +396,11 @@ __host__ void calcLRcore(GPUBuffer &reblurred, GPUBuffer &raw, int nx, int ny,
   unsigned nThreads = 1024;
   unsigned NXBlocks = ceil(((float)(nx * ny * nz)) / nThreads);
   unsigned NYBlocks = 1;
-  if (NXBlocks > maxGridXdim)
-    NYBlocks = NXBlocks = ceil(sqrt(NXBlocks));
+  if (NXBlocks > maxGridXdim) {
+    NYBlocks = NXBlocks / maxGridXdim + 1;
+    NXBlocks = maxGridXdim;
+    // NYblocks = NXblocks = ceil(sqrt(NXblocks));
+  }
 
   dim3 grid(NXBlocks, NYBlocks);
   dim3 block(nThreads);
@@ -376,8 +442,11 @@ __host__ void updateCurrEstimate(GPUBuffer &X_k, GPUBuffer &CC, GPUBuffer &Y_k,
   unsigned nThreads = 1024;
   unsigned NXBlocks = ceil(((float)(nx * ny * nz)) / nThreads);
   unsigned NYBlocks = 1;
-  if (NXBlocks > maxGridXdim)
-    NYBlocks = NXBlocks = ceil(sqrt(NXBlocks));
+  if (NXBlocks > maxGridXdim) {
+    NYBlocks = NXBlocks / maxGridXdim + 1;
+    NXBlocks = maxGridXdim;
+    // NYblocks = NXblocks = ceil(sqrt(NXblocks));
+  }
 
   dim3 grid(NXBlocks, NYBlocks);
   dim3 block(nThreads);
@@ -411,8 +480,11 @@ __host__ void calcCurrPrevDiff(GPUBuffer &X_k, GPUBuffer &Y_k,
 
   unsigned NXBlocks = ceil(((float)(nx * ny * nz)) / nThreads);
   unsigned NYBlocks = 1;
-  if (NXBlocks > maxGridXdim)
-    NYBlocks = NXBlocks = ceil(sqrt(NXBlocks));
+  if (NXBlocks > maxGridXdim) {
+    NYBlocks = NXBlocks / maxGridXdim + 1;
+    NXBlocks = maxGridXdim;
+    // NYblocks = NXblocks = ceil(sqrt(NXblocks));
+  }
 
   dim3 grid(NXBlocks, NYBlocks);
   dim3 block(nThreads);
@@ -598,8 +670,11 @@ __host__ double meanAboveBackground_GPU(GPUBuffer &img, int nx, int ny, int nz,
   unsigned nThreads = 1024;
   unsigned nXblocks = ceil(nx * ny * nz / (float)nThreads / 2);
   unsigned nYblocks = 1;
-  if (nXblocks > maxGridXdim)
-    nYblocks = nXblocks = ceil(sqrt(nXblocks));
+  if (nXblocks > maxGridXdim) {
+    nYblocks = nXblocks / maxGridXdim + 1;
+    nXblocks = maxGridXdim;
+    // nYblocks = nXblocks = ceil(sqrt(nXblocks));
+  }
 
   unsigned smemSize = nThreads * sizeof(double);
 
@@ -683,7 +758,7 @@ __global__ void summation_kernel(float *img, double *intRes, int n)
   }
   // write result for this block to global mem
   if (tid == 0)
-    intRes[blockIdx.x] = sdata[0];
+    intRes[blockIdx.y*gridDim.x+blockIdx.x] = sdata[0];
 }
 
 __global__ void sumAboveThresh_kernel(float *img, double *intRes,
@@ -746,8 +821,8 @@ __global__ void sumAboveThresh_kernel(float *img, double *intRes,
   }
   // write result for this block to global mem
   if (tid == 0) {
-    intRes[blockIdx.x] = sdata[0];
-    counter[blockIdx.x] = count[0];
+    intRes [blockIdx.y*gridDim.x+blockIdx.x] = sdata[0];
+    counter[blockIdx.y*gridDim.x+blockIdx.x] = count[0];
   }
 }
 
@@ -756,8 +831,11 @@ __host__ void rescale_GPU(GPUBuffer &img, int nx, int ny, int nz, float scale,
   unsigned nThreads = 1024;
   unsigned NXBlocks = ceil(nx * ny * nz / (float)nThreads);
   unsigned NYBlocks = 1;
-  if (NXBlocks > maxGridXdim)
-    NYBlocks = NXBlocks = ceil(sqrt(NXBlocks));
+  if (NXBlocks > maxGridXdim) {
+    NYBlocks = NXBlocks / maxGridXdim + 1;
+    NXBlocks = maxGridXdim;
+    // NYblocks = NXblocks = ceil(sqrt(NXblocks));
+  }
 
   scale_kernel<<<dim3(NXBlocks, NYBlocks), nThreads>>>((float *)img.getPtr(),
                                                        scale);

--- a/src/boostfs.cpp
+++ b/src/boostfs.cpp
@@ -1,5 +1,5 @@
 #include <boost/filesystem.hpp>
-#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/predicate.hpp>  // starts_with
 #include <regex>
 #include <iostream>
 #include <string>
@@ -28,9 +28,17 @@ std::vector<std::string> gatherMatchingFiles(std::string &target_path, std::stri
 	outputDir = dataDir / "GPUdecon";
 
   //***************** make regex filter ***************
+  // Check if the pattern is specified as a full file name; if so, insert
+  // an escape char '\' before '.'. Necessary?
+  size_t p1 = pattern.rfind(".tif");
+  size_t p2 = pattern.rfind(".TIF");
+  if (p1 != std::string::npos || p2 != std::string::npos) {
+    // do not append ".*tif" at the end of pattern
+  }
+  else 
+    pattern.append(".*\\.[tT][iI][fF]");
   pattern.insert(0, ".*");  // '.' is the wildcard in Perl regexp; '*' just means "repeat".
-  pattern.append(".*\\.tif");
-
+  std::cout << "file regex pattern: " << pattern << std::endl;
 
   const std::regex my_filter(pattern);
 

--- a/src/linearDecon.cpp
+++ b/src/linearDecon.cpp
@@ -199,6 +199,7 @@ int main(int argc, char *argv[])
 
     bool BlendTileOverlap = false;
     float deskewAngle=0.0;
+    bool bSkewedDecon = false;
     float rotationAngle=0.0;
     unsigned outputWidth;
     float padVal = 0.0;
@@ -238,7 +239,9 @@ int main(int argc, char *argv[])
     ("dupRevStack,d", po::bool_switch(&bDupRevStack)->default_value(false), "Duplicate reversed stack prior to decon to reduce Z ringing")
     ("NA,n", po::value<float>(&NA)->default_value(1.2), "Numerical aperture")
     ("RL,i", po::value<int>(&RL_iters)->default_value(15), "Run Richardson-Lucy, and set how many iterations")
-    ("deskew,D", po::value<float>(&deskewAngle)->default_value(0.0), "Deskew angle; if not 0.0 then perform deskewing before deconv")
+    ("deskew,D", po::value<float>(&deskewAngle)->default_value(0.0), "Deskew angle; if not 0.0 then perform deskewing before or afterdeconv")
+    ("dcbds", po::bool_switch(&bSkewedDecon)->implicit_value(true),
+     "If deskewing, do it after decon; require sample-scan PSF and non-RA 3D OTF")
     ("padval", po::value<float>(&padVal)->default_value(0.0), "Value to pad image with when deskewing")
     ("width,w", po::value<unsigned>(&outputWidth)->default_value(0), "If deskewed, the output image's width")
     ("shift,x", po::value<int>(&extraShift)->default_value(0), "If deskewed, the output image's extra shift in X (positive->left")
@@ -376,7 +379,7 @@ int main(int argc, char *argv[])
 
     CImg<> raw_image, raw_imageFFT, complexOTF, raw_deskewed, LSImage, sub_image, file_image, stitch_image, blend_weight_image;
     CImg<float> AverageLS;
-    float dkr_otf, dkz_otf;
+    float dkx_otf, dky_otf, dkz_otf;
     float dkx, dky, dkz, rdistcutoff;
     fftwf_plan rfftplan=NULL, rfftplan_inv=NULL;
     CPUBuffer rotMatrix;
@@ -387,6 +390,8 @@ int main(int argc, char *argv[])
     cufftHandle rfftplanGPU = NULL, rfftplanInvGPU = NULL;
     GPUBuffer d_interpOTF(1, myGPUdevice, UseOnlyHostMem);
     GPUBuffer workArea(1, myGPUdevice, UseOnlyHostMem);
+    // Lin: why were the above GPUBuffer()'s called with "1" as the first parameter ("size")??
+    GPUBuffer d_rawOTF(myGPUdevice, UseOnlyHostMem);
 
     cudaDeviceProp deviceProp;
     cudaGetDeviceProperties(&deviceProp, myGPUdevice);
@@ -634,10 +639,13 @@ int main(int argc, char *argv[])
                             bCrop = true;
                         }
 
-                        // only if no deskewing is happening do we want to change image width here
+                        // only if no deskewing is happening before decon do we want to change image width here
                         new_nx = startnx;
-                        if (!(fabs(deskewAngle) > 0.0)) {
+                        if (!(fabs(deskewAngle) > 0.0) || bSkewedDecon) {
                             new_nx = findOptimalDimension(startnx, step_size);
+                            if (new_nx%2 && new_nx>1000) // Lin: for unknown reason, an odd X dimension
+                              // sometimes results in doubled cuFFT work size; to-do...
+                              new_nx = findOptimalDimension(new_nx-1, step_size);
                             if (new_nx != startnx) {
                                 printf("new nx=%d\n", new_nx);
                                 bCrop = true;
@@ -654,12 +662,23 @@ int main(int argc, char *argv[])
                     //****************************Load OTF to CPU RAM(assuming 3D rotationally averaged OTF)***********************************
                     std::cout <<  "Loading OTF... ";
                     complexOTF.assign(otffiles.c_str());
-                    unsigned nr_otf = complexOTF.height();		// because it is rotationally averaged, kx = ky = kr
-                    unsigned nz_otf = complexOTF.width() / 2;	// because we are storing complex data in the .tiff file as two pixels: the real "width" is half the number of pixels in a row.
-                    dkr_otf = 1/((nr_otf-1)*2 * dr_psf);
-                    dkz_otf = 1/(nz_otf * dz_psf);
-                    std::cout << "nr x nz     : " << nr_otf << " x " << nz_otf << ". " << std::endl << std::endl ;
+                    // unsigned nr_otf = complexOTF.height();		// because it is rotationally averaged, kx = ky = kr
+                    // unsigned nz_otf = complexOTF.width() / 2;	// because we are storing complex data in the .tiff file as two pixels: the real "width" is half the number of pixels in a row.
+                    // dkr_otf = 1/((nr_otf-1)*2 * dr_psf);
+                    // dkz_otf = 1/(nz_otf * dz_psf);
+                    // std::cout << "nr x nz     : " << nr_otf << " x " << nz_otf << ". " << std::endl << std::endl ;
+                    unsigned nx_otf, ny_otf, nz_otf;
 
+                    if (bSkewedDecon && fabs(deskewAngle) > 0.0)
+                      dz_psf *= fabs(sin(deskewAngle * M_PI/180.));
+
+                    determine_OTF_dimensions(complexOTF, dr_psf, dz_psf,
+                                             nx_otf, ny_otf, nz_otf,
+                                             dkx_otf, dky_otf, dkz_otf);
+                    std::cout << "nx x ny x nz     : " << nx_otf << " x " << ny_otf << " x " << nz_otf << ". " << std::endl << std::endl ;
+                    // transfer raw OTF into device memory; texture TO-DO
+                    d_rawOTF.resize(nx_otf * ny_otf * nz_otf * sizeof(cuFloatComplex));
+                    cutilSafeCall(cudaMemcpy(d_rawOTF.getPtr(), complexOTF.data(), d_rawOTF.getSize(), cudaMemcpyDefault));
 
                     //****************************Construct deskew matrix***********************************
                     deskewedXdim = new_nx;
@@ -675,11 +694,11 @@ int main(int argc, char *argv[])
                             deskewedXdim = outputWidth; // use user-provided output width if available
 
                         // Adjust resolution to optimal FFT size if desired
-                        if (bAdjustResolution)
+                        if (bAdjustResolution&& !bSkewedDecon)
                             deskewedXdim = findOptimalDimension(deskewedXdim);
 
                         // update z step size:
-                        imgParams.dz *= sin(deskewAngle * M_PI/180.);
+                        imgParams.dz *= fabs(sin(deskewAngle * M_PI/180.));
                         if (fabs(deskewFactor) < 1)
                         {
                             #ifdef _WIN32
@@ -755,6 +774,9 @@ int main(int argc, char *argv[])
                         else
                             nz_final = new_nz;
 
+                        unsigned xdim4FFT = deskewedXdim;
+                        if (bSkewedDecon) xdim4FFT = new_nx;
+
                         if (0) {
                             // old way,  just autoallocate FFTplans.
                             // This will always be on the GPU, and the two plans 
@@ -792,15 +814,15 @@ int main(int argc, char *argv[])
 
                             cuFFTErr = cufftCreate(&rfftplanGPU);							// create object.
                             cuFFTErr = cufftSetAutoAllocation(rfftplanGPU, autoAllocate);
-                            cuFFTErr = cufftMakePlan3d(rfftplanGPU, new_nz, new_ny, deskewedXdim, CUFFT_R2C, &workSizeR2C);   // make plan, retrieve needed workSize
+                            cuFFTErr = cufftMakePlan3d(rfftplanGPU, nz_final, new_ny, xdim4FFT, CUFFT_R2C, &workSizeR2C);   // make plan, retrieve needed workSize
                             if (cuFFTErr != CUFFT_SUCCESS) {
                                 std::cerr << "cufftMakePlan3d() r2c failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
                                 cudaMemGetInfo(&GPUfree, &GPUtotal);
                                 std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
 
-                                cuFFTErr = cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_R2C, &workSizeR2C);
+                                cuFFTErr = cufftEstimate3d(new_nz, new_ny, xdim4FFT, CUFFT_R2C, &workSizeR2C);
                                 if (cuFFTErr != CUFFT_SUCCESS)
-                                    std::cerr << "cufftEstimate3d() failed. " << new_nz << " x " << new_ny << " x " << deskewedXdim << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+                                    std::cerr << "cufftEstimate3d() failed. " << new_nz << " x " << new_ny << " x " << xdim4FFT << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
 
                                 std::cerr << "R2C FFT Plan desires " << workSizeR2C / (1024 * 1024) << " MB. " << std::endl;
                                 throw std::runtime_error("cufftMakePlan3d() r2c failed.");
@@ -814,26 +836,22 @@ int main(int argc, char *argv[])
                             if (cuFFTErr != CUFFT_SUCCESS)
                                 std::cerr << "cufftSetAutoAllocation(rfftplanInvGPU, autoAllocate) failed. Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
 
-                            cuFFTErr = cufftMakePlan3d(rfftplanInvGPU, new_nz, new_ny, deskewedXdim, CUFFT_C2R, &workSizeC2R);// make plan, get workSize
+                            cuFFTErr = cufftMakePlan3d(rfftplanInvGPU, nz_final/*new_nz??*/, new_ny, xdim4FFT, CUFFT_C2R, &workSizeC2R);// make plan, get workSize
                             if (cuFFTErr != CUFFT_SUCCESS) {
-                                std::cerr << "cufftMakePlan3d() c2r failed. " << new_nz << " x " << new_ny << " x " << deskewedXdim << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+                                std::cerr << "cufftMakePlan3d() c2r failed. " << nz_final << " x " << new_ny << " x " << xdim4FFT << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
                                 cudaMemGetInfo(&GPUfree, &GPUtotal);
                                 std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
 
-                                cuFFTErr = cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_C2R, &workSizeC2R);
+                                cuFFTErr = cufftEstimate3d(new_nz, new_ny, xdim4FFT, CUFFT_C2R, &workSizeC2R);
                                 if (cuFFTErr != CUFFT_SUCCESS)
-                                    std::cerr << "cufftEstimate3d() failed. " << new_nz << " x " << new_ny << " x " << deskewedXdim << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
+                                    std::cerr << "cufftEstimate3d() failed. " << new_nz << " x " << new_ny << " x " << xdim4FFT << " Error code: " << cuFFTErr << " : " << _cudaGetErrorEnum(cuFFTErr) << std::endl;
 
                                 std::cerr << "C2R FFT Plan desires " << workSizeC2R / (1024 * 1024) << " MB. " << std::endl;
                                 throw std::runtime_error("cufftMakePlan3d() c2r failed.");
                             }
 
-                            if (workSizeC2R > workSizeR2C) {
-                                workSize = workSizeC2R;    // set workSize to max of C2R and R2C plans.
-                            }
-                            else {
-                                workSize = workSizeR2C;
-                            }
+                            // set workSize to max of C2R and R2C plans.
+                            workSize = std::max(workSizeC2R,workSizeR2C);
 
                             if (workArea.getSize() != workSize) {  // do we need to (re)allocate workArea?
                                 workArea.resize(workSize);
@@ -848,7 +866,7 @@ int main(int argc, char *argv[])
                                 cudaMemGetInfo(&GPUfree, &GPUtotal);
                                 std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
 
-                                cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_R2C, &workSizeR2C);
+                                cufftEstimate3d(new_nz, new_ny, xdim4FFT, CUFFT_R2C, &workSizeR2C);
                                 std::cerr << "R2C FFT Plan desires " << workSizeR2C / (1024 * 1024) << " MB. " << std::endl;
                                 throw std::runtime_error("cufftSetWorkArea() r2c failed.");
                             }
@@ -859,7 +877,7 @@ int main(int argc, char *argv[])
                                 cudaMemGetInfo(&GPUfree, &GPUtotal);
                                 std::cerr << "GPU " << GPUfree / (1024 * 1024) << " MB free / " << GPUtotal / (1024 * 1024) << " MB total. " << std::endl;
 
-                                cufftEstimate3d(new_nz, new_ny, deskewedXdim, CUFFT_C2R, &workSizeC2R);
+                                cufftEstimate3d(new_nz, new_ny, xdim4FFT, CUFFT_C2R, &workSizeC2R);
                                 std::cerr << "C2R FFT Plan desires " << workSizeC2R / (1024 * 1024) << " MB. " << std::endl;
                                 throw std::runtime_error("cufftSetWorkArea() c2r failed.");
                             }
@@ -869,16 +887,19 @@ int main(int argc, char *argv[])
                         std::cout << "FFT plans allocated.    ";
                         cudaMemGetInfo(&GPUfree, &GPUtotal);
                         std::cout << std::setw(8) << (GPUfree_prev - GPUfree) / (1024 * 1024) << "MB" << std::setw(8) << GPUfree / (1024 * 1024)
-                                  << "MB free" << " nz=" << new_nz << ", ny=" << new_ny << ", nx=" << deskewedXdim << std::endl;
+                                  << "MB free" << " nz=" << new_nz << ", ny=" << new_ny << ", nx=" << xdim4FFT << std::endl;
 
                     }  //else if (RL_iters>0)
 
                     //****************Transfer a bunch of constants to device, including OTF array:*******************
 
-                    dkx = 1.0/(imgParams.dr * deskewedXdim);
+                    unsigned xdim_during_decon = deskewedXdim;
+                    if (bSkewedDecon)
+                      xdim_during_decon = new_nx;
+                    dkx = 1.0/(imgParams.dr * xdim_during_decon);
                     dky = 1.0/(imgParams.dr * new_ny);
 
-                    unsigned nz_const;
+                    unsigned nz_const;  // same as "nz_final"??
                     if (bDupRevStack)
                         nz_const = new_nz*2;
                     else
@@ -888,14 +909,16 @@ int main(int argc, char *argv[])
                     rdistcutoff = 2*NA/(imgParams.wave); // lateral resolution limit in 1/um
                     float eps = std::numeric_limits<float>::epsilon();
 
-                    transferConstants(deskewedXdim, new_ny,
+                    transferConstants(xdim_during_decon, new_ny,
                                       nz_const,
-                                      complexOTF.height(), complexOTF.width()/2,
-                                      dkx/dkr_otf, dky/dkr_otf, dkz/dkz_otf,
-                                      eps, complexOTF.data());
+                                      // complexOTF.height(), complexOTF.width()/2,
+                                      nx_otf, ny_otf, nz_otf,
+                                      dkx/dkx_otf, dky/dky_otf, dkz/dkz_otf,
+                                      eps);
 
-                    d_interpOTF.resize(nz_const * new_ny * (deskewedXdim+2) * sizeof(float)); // allocate memory
-                    makeOTFarray(d_interpOTF, deskewedXdim, new_ny, nz_const); // interpolate.  This reads from the complexOTF.data sent to the GPU from transferConstants().
+                    d_interpOTF.resize(nz_const * new_ny * (xdim_during_decon/2+1)*2 * sizeof(float)); // allocate memory
+                    makeOTFarray(d_rawOTF, d_interpOTF, xdim_during_decon, new_ny, nz_const); // interpolate.
+                    d_rawOTF.resize(0);
                     std::cout << "d_interpOTF allocated.  ";
                     cudaMemGetInfo(&GPUfree, &GPUtotal);
                     std::cout << std::setw(8) << d_interpOTF.getSize() / (1024 * 1024) << "MB" << std::setw(8) << GPUfree / (1024 * 1024) << "MB free" << std::endl;
@@ -1067,8 +1090,29 @@ int main(int argc, char *argv[])
 
                 // If deskew is to happen, it'll be performed inside RichardsonLucy_GPU() on GPU;
                 // but here raw data's x dimension is still just "new_nx"
-                if (bCrop)
-                    raw_image.crop(0, 0, 0, 0, new_nx-1, new_ny-1, new_nz-1, 0);
+                if (bCrop) {
+                    //raw_image.crop(0, 0, 0, 0, new_nx-1, new_ny-1, new_nz-1, 0);
+                  // raw_image.crop((nx-new_nx)/2, (ny-new_ny)/2, (nz-new_nz)/2,
+                  //                (nx+new_nx)/2-1, (ny+new_ny)/2-1, (nz+new_nz)/2-1);
+
+                  // From Dan Milkie's commit b8ab540 12/07/2021
+                  int cropx_start = ((int) nx - (int) new_nx) / 2; // handle if new_nx is larger than nx (e.g. we are using padding.)
+                  int cropy_start = ((int) ny - (int) new_ny) / 2;
+                  int cropz_start = ((int) nz - (int) new_nz) / 2;
+
+                  cropx_start = std::max(cropx_start, 0); // don't go below zero.
+                  cropy_start = std::max(cropy_start, 0);
+                  cropz_start = std::max(cropz_start, 0);
+
+                  int cropx_end   = (cropx_start + new_nx) - 1; // cropping start and end are included in the region.
+                  int cropy_end   = (cropy_start + new_ny) - 1;
+                  int cropz_end   = (cropz_start + new_nz) - 1;
+			
+                  std::cout << "Cropping raw_image to      : " << cropx_start << " to "<< cropx_end << "  x  " << cropy_start << " to " << cropy_end << "  x  " << cropz_start << " to " << cropz_end << ". " << std::endl;
+
+                  raw_image.crop(cropx_start, cropy_start, cropz_start,
+                                 cropx_end,   cropy_end,   cropz_end);
+                }
 
                 if (wiener >0) { // plain 1-step Wiener filtering
                     raw_image -= background;
@@ -1077,7 +1121,7 @@ int main(int argc, char *argv[])
                     wienerfilter(raw_imageFFT,
                                  dkx, dky, dkz,
                                  complexOTF,
-                                 dkr_otf, dkz_otf,
+                                 dkx_otf, dkz_otf,
                                  rdistcutoff, wiener);
 
                     fftwf_execute_dft_c2r(rfftplan_inv, (fftwf_complex *) raw_imageFFT.data(), raw_image.data());
@@ -1108,7 +1152,7 @@ int main(int argc, char *argv[])
                     RichardsonLucy_GPU(raw_image, background, d_interpOTF, RL_iters, deskewFactor,
                                        deskewedXdim, extraShift, napodize, nZblend, rotMatrix,
                                        rfftplanGPU, rfftplanInvGPU, raw_deskewed, &deviceProp,
-                                       bFlatStartGuess, my_median, bDoRescale, padVal, bDupRevStack,
+                                       bFlatStartGuess, my_median, bDoRescale, bSkewedDecon, padVal, bDupRevStack,
                                        UseOnlyHostMem, myGPUdevice);
                     #ifdef USE_NVTX
                     cudaProfilerStop();

--- a/src/linearDecon.h
+++ b/src/linearDecon.h
@@ -150,17 +150,20 @@ void RichardsonLucy_GPU(CImg<> &raw, float background, GPUBuffer &otf,
                         cufftHandle rfftplanInvGPU,
                         CImg<> &raw_deskewed, cudaDeviceProp *devprop,
                         bool bFlatStartGuess, float my_median, bool bDoRescale,
+                        bool bSkewedDecon,
                         float padVal = 0, bool bDupRevStack = false,
                         bool UseOnlyHostMem = false, int myGPUdevice = 0);
 
 CImg<> MaxIntProj(CImg<> &input, int axis);
 
-void transferConstants(int nx, int ny, int nz, int nrotf, int nzotf,
-                       float kxscale, float kyscale, float kzscale, float eps,
-                       float *otf);
+void transferConstants(int nx, int ny, int nz, int nxotf, int nyotf, int nzotf,
+                       float kxscale, float kyscale, float kzscale, float eps);
 unsigned findOptimalDimension(unsigned inSize, int step = -1);
 // void prepareOTFtexture(float * realpart, float * imagpart, int nx, int ny);
-void makeOTFarray(GPUBuffer &otfarray, int nx, int ny, int nz);
+void determine_OTF_dimensions(CImg<> &complexOTF, float dr_psf, float dz_psf,
+                              unsigned &nx_otf, unsigned &ny_otf, unsigned &nz_otf,
+                              float &dkx_otf, float &dky_otf, float &dkz_otf);
+void makeOTFarray(GPUBuffer &raw_otfarray, GPUBuffer &otfarray, int nx, int ny, int nz);
 
 void backgroundSubtraction_GPU(GPUBuffer &img, int nx, int ny, int nz,
                                float background, unsigned maxGridXdim);
@@ -258,7 +261,8 @@ void makeNewDir(std::string subdirname);
   CUDADECON_API int RL_interface_init(int nx, int ny, int nz, float dr,
                                       float dz, float dr_psf, float dz_psf,
                                       float deskewAngle, float rotationAngle,
-                                      int outputWidth, char *OTF_file_name);
+                                      int outputWidth, bool bSkewedDecon,
+                                      char *OTF_file_name);
 
   //! RL_interface() to run deconvolution
   /*!
@@ -276,7 +280,7 @@ void makeNewDir(std::string subdirname);
       const unsigned short *const raw_data, int nx, int ny, int nz,
       float *result, float *raw_deskewed_result, float background,
       bool bDoRescale, bool bSaveDeskewedRaw, int nIters, int extraShift,
-      int napodize = 0, int nZblend = 0, float padVal = 0,
+      bool bSkewedDecon = false, int napodize = 0, int nZblend = 0, float padVal = 0,
       bool bDupRevStack = false);
 
   CUDADECON_API int Deskew_interface(

--- a/src/radialft-nonSIM.cpp
+++ b/src/radialft-nonSIM.cpp
@@ -5,8 +5,6 @@ namespace po = boost::program_options;
 #include <iostream>
 #include <complex>
 
-#include <stdio.h>
-
 #include <fftw3.h>
 
 #include <tiffio.h>
@@ -36,7 +34,9 @@ void cleanup(std::complex<float> *otfkxkz, int nx, int nz, float dkr, float dkz,
 void radialft(std::complex<float> *bands, int nx, int ny, int nz, std::complex<float> *avg);
 
 bool fixorigin(std::complex<float> *otfkxkz, int nx, int nz, int kx2);
+void fixorigin(CImg<> &otf3d, int kx2);
 void rescale(std::complex<float> *otfkxkz, int nx, int nz);
+void rescale(CImg<> &otf3d);
 
 
 int main(int argc, char **argv)
@@ -66,13 +66,14 @@ int main(int argc, char **argv)
   int krmax=0;
   bool bDoCleanup = true;
   bool bUserBackground = false;
+  bool b3Dout = false;
 
   po::options_description progopts;
   progopts.add_options()
     ("na", po::value<float>(&NA)->default_value(1.25), "NA of detection objective")
     ("nimm", po::value<float>(&NIMM)->default_value(1.3), "refractive index of immersion medium")
     ("xyres", po::value<float>(&dr)->default_value(.104), "x-y pixel size")
-    ("zres", po::value<float>(&dz)->default_value(.104), "z pixel size")
+    ("zres", po::value<float>(&dz)->default_value(.1), "z pixel size")
     ("wavelength", po::value<int>(&lambdanm)->default_value(530), "emission wavelength in nm")
     ("fixorigin", po::value<int>(&interpkr)->default_value(5),
      "for all kz, extrapolate using pixels kr=1 to this pixel to get value for kr=0")
@@ -80,6 +81,8 @@ int main(int argc, char **argv)
      "pixels outside this limit will be zeroed (overwriting estimated value from NA and NIMM)")
     ("nocleanup", po::bool_switch(&bDoCleanup)->implicit_value(false), "elect not to do clean-up outside OTF support")
     ("background", po::value<float>(&background), "use user-supplied background instead of the estimated")
+    ("3Dout,3", po::bool_switch(&b3Dout)->implicit_value(true),
+     "Output 3D, instead of rotationally averaged, OTF")
     ("input-file", po::value<std::string>(&ifiles)->required(), "input PSF file")
     ("output-file", po::value<std::string>(&ofiles)->required(), "output OTF file to write")
     ("help,h", "produce help message")
@@ -134,7 +137,8 @@ int main(int argc, char **argv)
   dkr = 1/(ny*dr);
   dkz = 1/(nz*dz);
 
-  nxy=(nx+2)*ny;
+  int nx2 = (nx/2+1)*2;   // in case nx is odd numbered, nx2 is nx+1, not nx+2
+  nxy=nx2*ny;
 
   floatimage = (float *) malloc(nxy*nz*sizeof(float));
   bands = (std::complex<float> *) floatimage;
@@ -144,7 +148,7 @@ int main(int argc, char **argv)
   for(z=0; z<nz; z++)
     for (i=0; i<ny; i++) {
       for (j=0; j<nx; j++)
-        floatimage[z*nxy+i*(nx+2)+j] = rawtiff(j, i, z);
+        floatimage[z*nxy+i*nx2+j] = rawtiff(j, i, z);
     }
 
   /* Before FFT, estimate bead center position */
@@ -159,7 +163,7 @@ int main(int argc, char **argv)
   for(z=0; z<nz; z++) {
     for(i=0;i<ny;i++)
       for(j=0;j<nx;j++)
-        floatimage[z*nxy + i*(nx+2) + j] -= background;
+        floatimage[z*nxy + i*nx2 + j] -= background;
   }
 
   rfftplan3d = fftwf_plan_dft_r2c_3d(nz, ny, nx, floatimage, 
@@ -176,6 +180,13 @@ int main(int argc, char **argv)
   shift_center(bands, nx, ny, nz, xcofm, ycofm, zcofm);
 
   CImg<> output_tiff(nz*2, nx/2+1, 1, 1, 0.f);
+  if (b3Dout) {
+    output_tiff.assign(floatimage, nx2, ny, nz, 1, true);
+    if (interpkr>1)
+      fixorigin(output_tiff, interpkr);
+    rescale(output_tiff);
+  }
+  else {
   avg_output = (std::complex<float> *) output_tiff.data();
 
   radialft(bands, nx, ny, nz, avg_output);
@@ -195,9 +206,8 @@ int main(int argc, char **argv)
     return false;
   }
 
-//  printf("%d\n", interpkr);
-  rescale(avg_output, nx, nz);
-
+    rescale(avg_output, nx, nz);
+  }
   /* For side bands, combine bandre's and bandim's into bandplus */
   /* Shouldn't this be done later on the averaged bands? */
 
@@ -207,13 +217,14 @@ int main(int argc, char **argv)
 /*  locate peak pixel to subpixel accuracy by fitting parabolas  */
 void determine_center_and_background(float *stack3d, int nx, int ny, int nz, float *xc, float *yc, float *zc, float *background)
 {
-  int i, j, k, maxi, maxj, maxk, ind, nxy2, infocus_sec;
+  int i, j, k, maxi=0, maxj=0, maxk=0, ind, nxy2, infocus_sec;
   int iminus, iplus, jminus, jplus, kminus, kplus;
   float maxval, reval, valminus, valplus;
   double sum;
 
   printf("In determine_center_and_background()\n");
-  nxy2 = (nx+2)*ny;
+  int nx2 = (nx/2+1)*2;   // in case nx is odd numbered, nx2 is nx+1, not nx+2
+  nxy2 = nx2*ny;
 
   /* Search for the peak pixel */
   /* Be aware that stack3d is of dimension (nx+2)xnyxnz */
@@ -221,13 +232,13 @@ void determine_center_and_background(float *stack3d, int nx, int ny, int nz, flo
   for(k=0;k<nz;k++)
     for(i=0;i<ny;i++)
       for(j=0;j<nx;j++) {
-    ind=k*nxy2+i*(nx+2)+j;
-    reval=stack3d[ind];
-    if( reval > maxval ) {
-      maxval = reval;
-      maxi=i; maxj=j;
-      maxk=k;
-    }
+        ind=k*nxy2+i*nx2+j;
+        reval=stack3d[ind];
+        if( reval > maxval ) {
+          maxval = reval;
+          maxi=i; maxj=j;
+          maxk=k;
+        }
       }
 
   iminus = maxi-1; iplus = maxi+1;
@@ -240,25 +251,25 @@ void determine_center_and_background(float *stack3d, int nx, int ny, int nz, flo
   if( kminus<0 ) kminus+=nz;
   if( kplus>=nz ) kplus-=nz;
 
-  valminus = stack3d[kminus*nxy2+maxi*(nx+2)+maxj];
-  valplus  = stack3d[kplus *nxy2+maxi*(nx+2)+maxj];
+  valminus = stack3d[kminus*nxy2+maxi*nx2+maxj];
+  valplus  = stack3d[kplus *nxy2+maxi*nx2+maxj];
   *zc = maxk + fitparabola(valminus, maxval, valplus);
 
   *zc += 0.6;
 
-  valminus = stack3d[maxk*nxy2+iminus*(nx+2)+maxj];
-  valplus  = stack3d[maxk*nxy2+iplus *(nx+2)+maxj];
+  valminus = stack3d[maxk*nxy2+iminus*nx2+maxj];
+  valplus  = stack3d[maxk*nxy2+iplus *nx2+maxj];
   *yc = maxi + fitparabola(valminus, maxval, valplus);
 
-  valminus = stack3d[maxk*nxy2+maxi*(nx+2)+jminus];
-  valplus  = stack3d[maxk*nxy2+maxi*(nx+2)+jplus];
+  valminus = stack3d[maxk*nxy2+maxi*nx2+jminus];
+  valplus  = stack3d[maxk*nxy2+maxi*nx2+jplus];
   *xc = maxj + fitparabola(valminus, maxval, valplus);
 
   sum = 0;
   infocus_sec = floor(*zc);
   for (i=0; i<*yc-20; i++)
     for (j=0; j<nx; j++)
-    sum += stack3d[infocus_sec*nxy2 + i*(nx+2) + j];
+      sum += stack3d[infocus_sec*nxy2 + i*nx2 + j];
   *background = sum / ((*yc-20)*nx);
 }
 
@@ -420,6 +431,49 @@ void cleanup(std::complex<float> *otfkxkz, int nx, int nz, float dkr, float dkz,
   }
 }
 
+void fixorigin(CImg<> &otf3d, int kx2)
+{
+  // Project 3D OTF onto kx-ky plane for the +/- 45-degree radial lines
+  int ny = otf3d.height();
+  int nx = otf3d.width()/2; // real and imaginary
+
+  CImg<> projected(nx*2, 1, 1, 1, 0.);
+
+  for (int z=0; z<otf3d.depth(); z++)
+    for (int x=1; x<nx; x++) {
+      int xst = x<<1;
+      // +45 degree line:
+      projected(xst)   += otf3d(xst, x, z);
+      projected(xst+1) += otf3d(xst+1, x, z);
+      // -45 degree line:
+      projected(xst)   += otf3d(xst, ny-x, z);
+      projected(xst+1) += otf3d(xst+1, ny-x, z);
+    }
+
+  //
+  std::complex<double> mean_val=0;
+  std::complex<double> slope_numerator=0;
+  std::complex<double> slope_denominat=0;
+  std::complex<float> * projectedC = (std::complex<float> *) projected.data();
+
+  for (int x=1; x<=kx2; x++)
+    mean_val += projectedC[x];
+  mean_val /= kx2;
+
+  double mean_kx = (kx2+1)/2.; // the mean of [1, 2, ..., n] is (n+1)/2
+  for (int x=1; x<=kx2; x++) {
+    std::complex<double> complexval = projectedC[x];
+    slope_numerator += (x - mean_kx) * (complexval - mean_val);
+    slope_denominat += (x - mean_kx) * (x - mean_kx);
+  }
+  std::complex<double> slope = slope_numerator / slope_denominat;
+  std::complex<double> valOrigin = mean_val - slope * mean_kx;   // intercept at kx=0
+  std::cout << "otf3d(0) = " << otf3d(0, 0, 0) << "+i" << otf3d(1,0,0) << std::endl;
+  otf3d(0, 0, 0) = valOrigin.real();
+  otf3d(1, 0, 0) = valOrigin.imag();
+  std::cout << "otf3d(0) = " << otf3d(0, 0, 0) << "+i" << otf3d(1,0,0) << std::endl;
+}
+
 bool fixorigin(std::complex<float> *otfkxkz, int nx, int nz, int kx2)
 {
   // linear fit the value at kx=0 using kx in [1, kx2]
@@ -468,3 +522,16 @@ void rescale(std::complex<float> *otfkxkz, int nx, int nz)
   }
 }
 
+void rescale(CImg<> &otf3d)
+{
+  std::complex<float> * otf3dC = (std::complex<float> *) otf3d.data();
+  size_t nxyz = otf3d.size() / 2;
+  float valmax = 0., mag;
+  for (unsigned i=0; i<nxyz; i++) {
+    mag = std::abs(otf3dC[i]);
+    if (mag > valmax)
+      valmax = mag;
+  }
+
+  otf3d /= valmax;
+}


### PR DESCRIPTION
1. Added support for using 3D, as opposed to rotationally averaged, OTF. "radialft" now uses flag "-3" to indicate 3D OTF is to be generated.
2. Added support for decon-then-deskew mode (using flag "-dcbds")
3. File name pattern can now include the file suffix like "rawimage.tif"
4. Dan's bug fixes for cropping images in linearDecon.cpp

This should have minimal formatting-related difference from the scopetools/cudaDecon's master branch