### PR TITLE
feat: export version in shared library

### DIFF
--- a/src/RL-Biggs-Andrews.cpp
+++ b/src/RL-Biggs-Andrews.cpp
@@ -1,4 +1,5 @@
 #include "linearDecon.h"
+#include "version.h"
 
 
 #include <vector>
@@ -463,6 +464,12 @@ unsigned deskewedXdim;
 CPUBuffer rotMatrix;
 cufftHandle rfftplanGPU, rfftplanInvGPU;
 GPUBuffer d_interpOTF(0, false); // since this is a global for th RL_interface dll, just leave device empty.  It will probably default to GPU 0.
+
+
+const char * get_version()
+{
+  return PROJECT_VERSION;
+}
 
 unsigned get_output_nx()
 {

--- a/src/linearDecon.h
+++ b/src/linearDecon.h
@@ -312,6 +312,9 @@ void makeNewDir(std::string subdirname);
   CUDADECON_API unsigned get_output_nx();
   CUDADECON_API unsigned get_output_ny();
   CUDADECON_API unsigned get_output_nz();
+  
+  // return version number 
+  CUDADECON_API const char* get_version();
 }
 
 #endif


### PR DESCRIPTION
adds a new symbol `get_version` to the shared library that returns the current version