### PR TITLE
suppress CImg warnings, fix all others

### DIFF
--- a/src/Buffers/CPUBuffer.cpp
+++ b/src/Buffers/CPUBuffer.cpp
@@ -159,9 +159,9 @@ bool CPUBuffer::hasNaNs(bool verbose) const
   } else {
     while ((!haveNaNs) && i < numEntries) {
 #ifndef _WIN32
-      haveNaNs |= std::isnan(arr[i]);
+      haveNaNs = haveNaNs || std::isnan(arr[i]);
 #else
-      haveNaNs |= _isnan(arr[i]);
+      haveNaNs = haveNaNs || _isnan(arr[i]);
 #endif
       ++i;
     }

--- a/src/Buffers/PinnedCPUBuffer.cpp
+++ b/src/Buffers/PinnedCPUBuffer.cpp
@@ -139,9 +139,9 @@ bool PinnedCPUBuffer::hasNaNs(bool verbose) const
   } else {
     while ((!haveNaNs) && i < numEntries) {
 #ifndef _WIN32
-      haveNaNs |= std::isnan(arr[i]);
+      haveNaNs = haveNaNs || std::isnan(arr[i]);
 #else
-      haveNaNs |= _isnan(arr[i]);
+      haveNaNs = haveNaNs || _isnan(arr[i]);
 #endif
       ++i;
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,12 @@ set(SCI_WORLD_PROGRAM_PERMS WORLD_READ WORLD_EXECUTE)
 # the command line, we want the compiler flag to be almost identical to the
 # ones used for Release except for -DNDEBUG
 
+
+########## suppress warnings from CImg.h ############################
+
+set(CIMG_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/CImg")
+include_directories(SYSTEM ${CIMG_INCLUDE_DIR})
+
 ######################################################################
 #
 # Set compilier


### PR DESCRIPTION
cleans up the compile logs.  Not sure when it will be time to update the included CImg.h file again, there are a number of warning, but since we don't edit that header directly, I'm suppressing them here